### PR TITLE
Added the "getStopwords" method, added a way to provide custom stopwords...

### DIFF
--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -42,7 +42,7 @@ function _extract(str, options){
             }
         }
         var results = [];
-        var _stopwords = stopwords[_language];
+        var _stopwords = options.stopwords || _getStopwords({ language: _language });
         for(var y = 0; y < low_words.length; y++){
             if(_stopwords.indexOf(low_words[y]) < 0){
                 var result_word = return_changed_case && !unchanged_words[y].match(/https?:\/\/.*[\r\n]*/g) ? low_words[y] : unchanged_words[y];
@@ -53,6 +53,18 @@ function _extract(str, options){
     }
 }
 
+function _getStopwords(options){
+    options = options || {};
+
+    var _language = options.language || "english";
+    if(supported_languages.indexOf(_language) < 0){
+        throw new Error("Language must be one of ["+supported_languages.join(",")+"]");
+    }
+
+    return stopwords[_language];
+}
+
 module.exports = {
-    extract:_extract
+    extract:_extract,
+    getStopwords: _getStopwords,
 };

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -92,4 +92,8 @@ describe("extractor", function(){
         extraction_result.should.eql(["president","obama","woke","monday","facing","congressional","defeat","parties","believed","hobble","presidency"]);
     });
 
+    it("should return an array of stopwords from the getStopwords method", function(){
+        extractor.getStopwords().should.not.be.empty;
+        extractor.getStopwords({language:"english"}).should.not.be.empty;
+    });
 });


### PR DESCRIPTION
I'm using elasticsearch, so I needed a way to use the same stopwords on elasticsearch and on my code.

I added a method that returns the stopwords, and a way to provide custom stopwords to the extractor. I also did the test for this method.
