### PR TITLE
Added return_max_ngrams option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ remove_digits | Removes all digits from the results if set to true | _true_ or _
 return_changed_case | The case of the extracted keywords. Setting the value to _true_ will return the results all lower-cased, if _false_ the results will be in the original case. | _true_ or _false_
 return_chained_words | Instead of returning each word separately, join the words that were originally together. Setting the value to _true_ will join the words, if _false_ the results will be splitted on each array element. | _true_ or _false_
 remove_duplicates | Removes the duplicate keywords | _true_ , _false_ (defaults to _false_ )
+remove_max_ngrams | Returns keywords that are ngrams with size 0-_integer_  | _integer_ , _false_ (defaults to _false_ )
 
 
 ## Credits

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -53,17 +53,21 @@ function _extract(str, options){
         var results = [];
         var _stopwords = options.stopwords || _getStopwords({ language: _language });
         var _last_result_word_index = 0;
-        var _start_result_word_index = 0
+        var _start_result_word_index = 0;
+	var _unbroken_word_chain = false;
         for(var y = 0; y < low_words.length; y++){
 
             if(_stopwords.indexOf(low_words[y]) < 0){
                 
                 if(_last_result_word_index !== y - 1){
                     _start_result_word_index = y;
-                }
+                    _unbroken_word_chain = false; 
+		} else {
+	            _unbroken_word_chain = true;
+		}
                 var result_word = return_changed_case && !unchanged_words[y].match(/https?:\/\/.*[\r\n]*/g) ? low_words[y] : unchanged_words[y];
                 
-                if (return_max_ngrams && !return_chained_words && return_max_ngrams >= (y - _start_result_word_index) && _last_result_word_index === y - 1){
+                if (return_max_ngrams && _unbroken_word_chain && !return_chained_words && return_max_ngrams > (y - _start_result_word_index) && _last_result_word_index === y - 1){
                     var change_pos = results.length - 1 < 0 ? 0 : results.length - 1;
                     results[change_pos] = results[change_pos] ? results[change_pos] + ' ' + result_word : result_word;
                 } else if (return_chained_words && _last_result_word_index === y - 1) {
@@ -74,7 +78,9 @@ function _extract(str, options){
                 }
 
                 _last_result_word_index = y;
-            }
+            } else {
+		_unbroken_word_chain = false;
+	    }
         }
 
         if(_remove_duplicates) {

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -10,8 +10,7 @@ function _extract(str, options){
     if(_.isEmpty(options)){
         options = {
             remove_digits: true,
-            return_changed_case: true,
-            return_max_ngrams: false
+            return_changed_case: true
         };
     }
     var return_changed_case = options.return_changed_case;

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -10,7 +10,8 @@ function _extract(str, options){
     if(_.isEmpty(options)){
         options = {
             remove_digits: true,
-            return_changed_case: true
+            return_changed_case: true,
+            return_max_ngrams: false
         };
     }
     var return_changed_case = options.return_changed_case;
@@ -18,6 +19,7 @@ function _extract(str, options){
     var remove_digits = options.remove_digits;
     var _language = options.language || "english";
     var _remove_duplicates = options.remove_duplicates || false;
+    var return_max_ngrams = options.return_max_ngrams;
 
     if(supported_languages.indexOf(_language) < 0){
         throw new Error("Language must be one of ["+supported_languages.join(",")+"]");
@@ -52,12 +54,20 @@ function _extract(str, options){
         var results = [];
         var _stopwords = options.stopwords || _getStopwords({ language: _language });
         var _last_result_word_index = 0;
+        var _start_result_word_index = 0
         for(var y = 0; y < low_words.length; y++){
 
             if(_stopwords.indexOf(low_words[y]) < 0){
+                
+                if(_last_result_word_index !== y - 1){
+                    _start_result_word_index = y;
+                }
                 var result_word = return_changed_case && !unchanged_words[y].match(/https?:\/\/.*[\r\n]*/g) ? low_words[y] : unchanged_words[y];
-
-                if (return_chained_words && _last_result_word_index === y - 1) {
+                
+                if (return_max_ngrams && !return_chained_words && return_max_ngrams >= (y - _start_result_word_index) && _last_result_word_index === y - 1){
+                    var change_pos = results.length - 1 < 0 ? 0 : results.length - 1;
+                    results[change_pos] = results[change_pos] ? results[change_pos] + ' ' + result_word : result_word;
+                } else if (return_chained_words && _last_result_word_index === y - 1) {
                   var change_pos = results.length - 1 < 0 ? 0 : results.length - 1;
                   results[change_pos] = results[change_pos] ? results[change_pos] + ' ' + result_word : result_word;
                 } else {

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -49,6 +49,23 @@ describe("extractor", function(){
           'presidencia'
       ]);
     });
+    
+    it("should return an array of chained 'keywords' with maximum length of 2 for a Spanish string", function() {
+      var extraction_result = extractor.extract("Presidente Obama se despertó el lunes enfrentado a una derrota del Congreso que muchos en ambas partes creyeron que podría entorpecer su presidencia.", {
+          language:"spanish",
+          return_max_ngrams: 2
+      });
+      extraction_result.should.not.be.empty;
+      extraction_result.should.eql([
+          'Presidente Obama',
+          'despertó',
+          'lunes enfrentado',
+          'derrota',
+          'Congreso',
+          'podría entorpecer',
+          'presidencia'
+      ]);
+    });
 
     it("should return an array of 'keywords' for a Spanish string", function(){
         var extraction_result = extractor.extract("Presidente Obama despertó Lunes enfrenta a una derrota del Congreso que muchos en ambas partes creyeron podrían entorpecer su presidencia.",{


### PR DESCRIPTION
This PR adds the *return_max_ngrams* option to this module, which allows the user to specify the maximum ngram length they wish to match keywords by.

Aka this does the same thing as return_chain_keywords but with the added option of specifying the maximum length of a chained keyword.