### PR TITLE
Bump version to 0.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "search",
         "extract"
     ],
-    "version": "0.0.17",
+    "version": "0.0.18",
     "licenses": [
         {
             "type": "MIT",


### PR DESCRIPTION
Updates package version after upgrade of `mixin-deep` dependency.