### PR TITLE
Add types to extract and getStopwords functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "keyword-extractor",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "author": "Michael De Lorenzo <michael@delorenzodesign.com> (http://mikedelorenzo.com)",
     "name": "keyword-extractor",
     "description": "Module for creating a keyword array from a string and excluding stop words.",
+    "types": "types/index.d.ts",
     "keywords": [
         "text",
         "keyword",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,8 @@
+import {ExtractionOptions, GetStopwordsOptions} from "./lib/keyword_extractor";
+
+declare const keyword_extractor: {
+  extract: (str: string, options?: ExtractionOptions) => string[];
+  getStopwords: (options?: GetStopwordsOptions) => string[];
+};
+
+export default keyword_extractor;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,8 @@
 import {ExtractionOptions, GetStopwordsOptions} from "./lib/keyword_extractor";
 
+/**
+ * Tools for extracting keywords from a string by removing stopwords.
+ */
 declare const keyword_extractor: {
   extract: (str: string, options?: ExtractionOptions) => string[];
   getStopwords: (options?: GetStopwordsOptions) => string[];

--- a/types/lib/keyword_extractor.d.ts
+++ b/types/lib/keyword_extractor.d.ts
@@ -1,0 +1,25 @@
+
+type LanguageName = "danish"|"dutch"|"english"|"french"|"galician"|"german"|"italian"|"polish"|"portuguese"|"romanian"|"russian"|"spanish"|"swedish";
+type GetStopwordsOptions = {language?: LanguageName};
+type ExtractionOptions = {
+  remove_digits?: boolean;
+  return_changed_case?: boolean;
+  return_chained_words?: boolean;
+  remove_duplicates?: boolean;
+  return_max_ngrams?: number | false;
+  stopwords?: string[];
+} & GetStopwordsOptions;
+
+/**
+ * Extracts keywords from the given string.
+ * @param {string} str The string to extract keywords from.
+ * @param {ExtractionOptions | undefined} options Options for the keyword extraction tool.
+ */
+export declare function _extract(str: string, options?: ExtractionOptions): string[]
+
+
+/**
+ * Returns the array of stopwords.
+ * @param {GetStopwordsOptions | undefined} options
+ */
+export declare function _getStopwords(options?: GetStopwordsOptions): string[];


### PR DESCRIPTION
Hi, I needed to extract some keywords for a TypeScript project recently and found this package! I added some type declaration files for the `extract` and `getStopwords` functions.