### PR TITLE
remove bullet symbols and hyphen from single character string

### DIFF
--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -59,7 +59,7 @@ function extract(
       //  remove periods, question marks, exclamation points, commas, and semi-colons
       //  if this is a short result, make sure it's not a single character or something 'odd'
       if (w.length === 1) {
-        w = w.replace(/_|@|&|#/g, "");
+        w = w.replace(/_|@|&|#|·|-|/g, "");
       }
       //  if it's a number, remove it
       const digits_match = w.match(/\d/g);


### PR DESCRIPTION
I got three bullet symbols in output array. But these bullet symbols doesn't mean any thing. So it is better to remove these symbols from final output array.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed bullet symbols and hyphens from single-character strings in keyword extraction to clean up the output.

<!-- End of auto-generated description by cubic. -->

