### PR TITLE
feat(release): add semantic-release automation and PR title enforcement

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,39 @@
+# Enforces that pull request titles follow the Conventional Commits
+# specification, since the release workflow uses the squashed PR title as
+# the commit message that drives semantic-release's version bump.
+
+name: pr title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            style
+            test
+            build
+            ci
+            chore
+            revert

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+# This workflow runs semantic-release on every push to main, determining the
+# next version from conventional commit messages, publishing to npm, and
+# creating a GitHub release with generated notes.
+
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: make test.ci
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  # Lets @semantic-release/npm publish via npm Trusted Publishing (OIDC)
+  # instead of a long-lived NPM_TOKEN. See the Release step below.
   id-token: write
 
 concurrency:
@@ -43,5 +45,9 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # npm is configured for Trusted Publishing (OIDC) on this package,
+          # so @semantic-release/npm authenticates using the id-token above
+          # and never needs this. Left as a fallback in case Trusted
+          # Publishing is ever removed on the npm side.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -27,14 +31,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run tests
-        run: make test.ci
+        run: make test
 
       - name: Release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,7 @@
     "branches": [
         "main"
     ],
+    "tagFormat": "${version}",
     "plugins": [
         [
             "@semantic-release/commit-analyzer",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,33 @@
+{
+    "branches": [
+        "main"
+    ],
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        "@semantic-release/changelog",
+        "@semantic-release/npm",
+        "@semantic-release/github",
+        [
+            "@semantic-release/git",
+            {
+                "assets": [
+                    "CHANGELOG.md",
+                    "package.json",
+                    "package-lock.json"
+                ],
+                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+            }
+        ]
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Common types and the version bump they trigger:
 
 Type       | Description                                | Release
 -----------|---------------------------------------------|--------
-`fix`      | A bug fix                                    | Patch
+`fix`, `perf`, `revert` | A bug fix, performance fix, or revert of a previous commit | Patch
 `feat`     | A new feature                                | Minor
-`perf`, `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore` | No user-facing change | None
+`refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore` | No user-facing change | None
 Any type with a `BREAKING CHANGE:` footer or a `!` after the type/scope (e.g. `feat!:`) | Breaking API change | Major
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ remove_duplicates | Removes the duplicate keywords | _true_ , _false_ (defaults 
 return_max_ngrams | Returns keywords that are ngrams with size 0-_integer_ | _integer_ , _false_ (defaults to _false_ )
 
 
+## Releases
+
+This package is released to npm automatically using [semantic-release](https://semantic-release.gitbook.io/semantic-release/).
+Every merge to `main` is analyzed and, if it contains a releasable change, published under the appropriate version bump.
+
+Versioning is driven entirely by commit messages (and, by extension, pull request titles — PRs are typically squash-merged,
+so the PR title becomes the commit message on `main`). Pull request titles must follow the
+[Conventional Commits](https://www.conventionalcommits.org/) specification and are checked automatically by CI:
+
+```
+<type>[optional scope]: <description>
+```
+
+Common types and the version bump they trigger:
+
+Type       | Description                                | Release
+-----------|---------------------------------------------|--------
+`fix`      | A bug fix                                    | Patch
+`feat`     | A new feature                                | Minor
+`perf`, `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore` | No user-facing change | None
+Any type with a `BREAKING CHANGE:` footer or a `!` after the type/scope (e.g. `feat!:`) | Breaking API change | Major
+
 ## Credits
 
 The initial stopwords lists are taken from the following sources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,588 @@
             "name": "keyword-extractor",
             "version": "0.0.28",
             "devDependencies": {
+                "@semantic-release/changelog": "^7.0.0",
+                "@semantic-release/commit-analyzer": "^13.0.1",
+                "@semantic-release/git": "^11.0.1",
+                "@semantic-release/github": "^12.0.9",
+                "@semantic-release/npm": "^13.1.5",
+                "@semantic-release/release-notes-generator": "^14.1.1",
                 "browserify": "^17.0.1",
+                "conventional-changelog-conventionalcommits": "^10.3.0",
                 "esm": "^3.2.25",
                 "mocha": "^10.8.2",
+                "semantic-release": "^25.0.9",
                 "should": "^13.2.3"
             },
             "engines": {
                 "node": ">= 0.10.0"
             }
+        },
+        "node_modules/@actions/core": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+            "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/exec": "^3.0.0",
+                "@actions/http-client": "^4.0.0"
+            }
+        },
+        "node_modules/@actions/exec": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+            "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/io": "^3.0.2"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+            "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^6.23.0"
+            }
+        },
+        "node_modules/@actions/http-client/node_modules/undici": {
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
+        "node_modules/@actions/io": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+            "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@colors/colors": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@conventional-changelog/template": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
+            "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+            "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.4",
+                "@octokit/request": "^10.0.13",
+                "@octokit/request-error": "^7.1.1",
+                "@octokit/types": "^17.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+            "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^17.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+            "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^10.0.13",
+                "@octokit/types": "^17.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "28.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+            "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^27.0.0"
+            }
+        },
+        "node_modules/@octokit/plugin-retry": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
+            "integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request-error": "^7.1.1",
+                "@octokit/types": "^17.0.0",
+                "bottleneck": "^2.15.3"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=7"
+            }
+        },
+        "node_modules/@octokit/plugin-throttling": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
+            "integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^17.0.0",
+                "bottleneck": "^2.15.3"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": "^7.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "10.0.13",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+            "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.1.1",
+                "@octokit/types": "^17.0.0",
+                "content-type": "^2.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+            "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^17.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+            "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^28.0.0"
+            }
+        },
+        "node_modules/@pnpm/config.env-replace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "4.2.10"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@pnpm/npm-conf": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+            "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pnpm/config.env-replace": "^1.1.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@semantic-release/changelog": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-7.0.0.tgz",
+            "integrity": "sha512-TNPyag5db24o7jWjre7UwKB4EcL8oJxbRhnDQ7hmZRAYqzreAc6PgdxQuU3pppp5xQinYtiumL0iG8SSKvnlzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "lodash-es": "^4.17.21"
+            },
+            "engines": {
+                "node": "^22.22.2 || >=24.15"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@semantic-release/commit-analyzer": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+            "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "import-from-esm": "^2.0.0",
+                "lodash-es": "^4.17.21",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@semantic-release/error": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+            "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@semantic-release/git": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-11.0.1.tgz",
+            "integrity": "sha512-Zr8BUYCTZMc8V6wDKN2dpR7nJgewd9I6THL3ydLTnp3OEdTo1/4RBLNYaeRucYMsjMv+BXoCNfXA0NADj1kwhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "debug": "^4.0.0",
+                "dir-glob": "^3.0.0",
+                "execa": "^10.0.0",
+                "lodash-es": "^4.17.21",
+                "micromatch": "^4.0.0",
+                "p-reduce": "^3.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || >=24.15"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@semantic-release/github": {
+            "version": "12.0.9",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.9.tgz",
+            "integrity": "sha512-ODIqb0V3QqndipryEEiaBxUQCFjvv7Oese5Dt4omMGa60YRNEW0Sx3K+zri0uac2Y6S9nOlMehciWIzvvRCTGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "^7.0.0",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-retry": "^8.0.0",
+                "@octokit/plugin-throttling": "^11.0.0",
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "debug": "^4.3.4",
+                "dir-glob": "^3.0.1",
+                "http-proxy-agent": "^9.0.0",
+                "https-proxy-agent": "^9.0.0",
+                "issue-parser": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "mime": "^4.0.0",
+                "p-filter": "^4.0.0",
+                "tinyglobby": "^0.2.14",
+                "undici": "^7.0.0",
+                "url-join": "^5.0.0"
+            },
+            "engines": {
+                "node": "^22.14.0 || >= 24.10.0"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=24.1.0"
+            }
+        },
+        "node_modules/@semantic-release/npm": {
+            "version": "13.1.5",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+            "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/core": "^3.0.0",
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "env-ci": "^11.2.0",
+                "execa": "^9.0.0",
+                "fs-extra": "^11.0.0",
+                "lodash-es": "^4.17.21",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^9.0.0",
+                "npm": "^11.6.2",
+                "rc": "^1.2.8",
+                "read-pkg": "^10.0.0",
+                "registry-auth-token": "^5.0.0",
+                "semver": "^7.1.2",
+                "tempy": "^3.0.0"
+            },
+            "engines": {
+                "node": "^22.14.0 || >= 24.10.0"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/release-notes-generator": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+            "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "import-from-esm": "^2.0.0",
+                "lodash-es": "^4.17.21",
+                "read-package-up": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/@simple-libs/stream-utils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+            "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "7.4.1",
@@ -49,6 +623,33 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/aggregate-error": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+            "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clean-stack": "^5.2.0",
+                "indent-string": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -57,6 +658,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/ansi-escapes": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
@@ -83,6 +700,13 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/anymatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -101,6 +725,20 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
+        },
+        "node_modules/argv-formatter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/asn1.js": {
             "version": "5.4.1",
@@ -173,6 +811,13 @@
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
         },
+        "node_modules/before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -187,6 +832,13 @@
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
             "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
             "dev": true
+        },
+        "node_modules/bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "2.1.4",
@@ -482,6 +1134,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/camelcase": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -520,6 +1182,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/chokidar": {
@@ -564,6 +1236,73 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/clean-stack": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+            "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "5.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/clean-stack/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-highlight": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+            "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "highlight.js": "^10.7.1",
+                "mz": "^2.4.0",
+                "parse5": "^5.1.1",
+                "parse5-htmlparser2-tree-adapter": "^6.0.0",
+                "yargs": "^16.0.0"
+            },
+            "bin": {
+                "highlight": "bin/highlight"
+            },
+            "engines": {
+                "node": ">=8.0.0",
+                "npm": ">=5.0.0"
+            }
+        },
+        "node_modules/cli-table3": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": "10.* || >= 12.*"
+            },
+            "optionalDependencies": {
+                "@colors/colors": "1.5.0"
+            }
+        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -605,6 +1344,17 @@
                 "source-map": "~0.5.3"
             }
         },
+        "node_modules/compare-func": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^5.1.0"
+            }
+        },
         "node_modules/concat-stream": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -620,6 +1370,17 @@
                 "typedarray": "^0.0.6"
             }
         },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
         "node_modules/console-browserify": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -632,6 +1393,106 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
+        "node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/conventional-changelog-angular": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+            "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-conventionalcommits": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
+            "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@conventional-changelog/template": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/conventional-changelog-writer": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+            "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-parser": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
@@ -643,6 +1504,52 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
+        },
+        "node_modules/cosmiconfig": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/create-ecdh": {
             "version": "4.0.4",
@@ -687,6 +1594,31 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/crypto-browserify": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -707,6 +1639,35 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/crypto-random-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/crypto-random-string/node_modules/type-fest": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/dash-ast": {
@@ -743,6 +1704,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/define-data-property": {
@@ -837,6 +1808,19 @@
             "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
             "dev": true
         },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -845,6 +1829,19 @@
             "engines": {
                 "node": ">=0.4",
                 "npm": ">=1.2"
+            }
+        },
+        "node_modules/dot-prop": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-obj": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/dunder-proto": {
@@ -896,6 +1893,149 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/emojilib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/env-ci": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+            "integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^8.0.0",
+                "java-properties": "^1.0.2"
+            },
+            "engines": {
+                "node": "^18.17 || >=20.6.1"
+            }
+        },
+        "node_modules/env-ci/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/env-ci/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "node_modules/env-ci/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -976,11 +2116,80 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "node_modules/execa": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
+            "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.1",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.3.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "which-command": "^0.1.0",
+                "yoctocolors": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/execa/node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/fast-safe-stringify": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
             "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
             "dev": true
+        },
+        "node_modules/figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/figures/node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
@@ -1010,6 +2219,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/find-up-simple": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-versions": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+            "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver-regex": "^4.0.5",
+                "super-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -1032,6 +2271,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+            "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -1063,6 +2317,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-assigned-identifiers": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
@@ -1076,6 +2343,19 @@
             "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -1113,6 +2393,38 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/git-log-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
+            "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argv-formatter": "~1.0.0",
+                "spawn-error-forwarder": "~1.0.0",
+                "split2": "~1.0.0",
+                "stream-combiner2": "~1.1.1",
+                "through2": "~2.0.0",
+                "traverse": "0.6.8"
             }
         },
         "node_modules/glob": {
@@ -1157,6 +2469,45 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/handlebars/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/has": {
@@ -1265,6 +2616,16 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/hmac-drbg": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -1276,6 +2637,32 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
+        "node_modules/hook-std": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-4.0.0.tgz",
+            "integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/htmlescape": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
@@ -1285,17 +2672,135 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/https-browserify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
+        "node_modules/https-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "dev": true
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/import-from-esm": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+            "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "import-meta-resolve": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18.20"
+            }
+        },
+        "node_modules/import-meta-resolve": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/index-to-position": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -1312,6 +2817,13 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/inline-source-map": {
             "version": "0.6.2",
@@ -1351,6 +2863,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -1442,6 +2961,16 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -1449,6 +2978,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-typed-array": {
@@ -1484,6 +3026,47 @@
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
         },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/issue-parser": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+            "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.capitalize": "^4.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.uniqby": "^4.7.0"
+            },
+            "engines": {
+                "node": "^18.17 || >=20.6.1"
+            }
+        },
+        "node_modules/java-properties": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+            "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-yaml": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -1505,6 +3088,40 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-with-bigint": {
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+            "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/jsonparse": {
@@ -1542,6 +3159,43 @@
                 "stream-splicer": "^2.0.0"
             }
         },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/load-json-file/node_modules/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1557,11 +3211,53 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash-es": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.capitalize": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lodash.memoize": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
             "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
             "dev": true
+        },
+        "node_modules/lodash.uniqby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+            "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -1577,6 +3273,95 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/marked": {
+            "version": "15.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/marked-terminal": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+            "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "ansi-regex": "^6.1.0",
+                "chalk": "^5.4.1",
+                "cli-highlight": "^2.1.11",
+                "cli-table3": "^0.6.5",
+                "node-emoji": "^2.2.0",
+                "supports-hyperlinks": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "marked": ">=1 <16"
+            }
+        },
+        "node_modules/marked-terminal/node_modules/ansi-regex": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/marked-terminal/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/math-intrinsics": {
@@ -1599,6 +3384,40 @@
                 "safe-buffer": "^5.1.2"
             }
         },
+        "node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
         "node_modules/miller-rabin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -1617,6 +3436,35 @@
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
             "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
             "dev": true
+        },
+        "node_modules/mime": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+            "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa"
+            ],
+            "license": "MIT",
+            "bin": {
+                "mime": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
@@ -1747,6 +3595,63 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nerf-dart": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-emoji": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^4.6.0",
+                "char-regex": "^1.0.2",
+                "emojilib": "^2.4.0",
+                "skin-tone": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/normalize-package-data": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+            "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1754,6 +3659,1943 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/normalize-url": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+            "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm": {
+            "version": "11.19.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
+            "integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
+            "bundleDependencies": [
+                "@isaacs/string-locale-compare",
+                "@npmcli/arborist",
+                "@npmcli/config",
+                "@npmcli/fs",
+                "@npmcli/map-workspaces",
+                "@npmcli/metavuln-calculator",
+                "@npmcli/package-json",
+                "@npmcli/promise-spawn",
+                "@npmcli/redact",
+                "@npmcli/run-script",
+                "@sigstore/tuf",
+                "abbrev",
+                "archy",
+                "cacache",
+                "chalk",
+                "ci-info",
+                "fastest-levenshtein",
+                "fs-minipass",
+                "glob",
+                "graceful-fs",
+                "hosted-git-info",
+                "ini",
+                "init-package-json",
+                "is-cidr",
+                "json-parse-even-better-errors",
+                "libnpmaccess",
+                "libnpmdiff",
+                "libnpmexec",
+                "libnpmfund",
+                "libnpmorg",
+                "libnpmpack",
+                "libnpmpublish",
+                "libnpmsearch",
+                "libnpmteam",
+                "libnpmversion",
+                "make-fetch-happen",
+                "minimatch",
+                "minipass",
+                "minipass-pipeline",
+                "ms",
+                "node-gyp",
+                "nopt",
+                "npm-audit-report",
+                "npm-install-checks",
+                "npm-package-arg",
+                "npm-pick-manifest",
+                "npm-profile",
+                "npm-registry-fetch",
+                "npm-user-validate",
+                "p-map",
+                "pacote",
+                "parse-conflict-json",
+                "proc-log",
+                "qrcode-terminal",
+                "read",
+                "semver",
+                "spdx-expression-parse",
+                "ssri",
+                "supports-color",
+                "tar",
+                "text-table",
+                "tiny-relative-date",
+                "treeverse",
+                "validate-npm-package-name",
+                "which"
+            ],
+            "dev": true,
+            "license": "Artistic-2.0",
+            "workspaces": [
+                "docs",
+                "smoke-tests",
+                "mock-globals",
+                "mock-registry",
+                "workspaces/*"
+            ],
+            "dependencies": {
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/arborist": "^9.9.1",
+                "@npmcli/config": "^10.12.0",
+                "@npmcli/fs": "^5.0.0",
+                "@npmcli/map-workspaces": "^5.0.3",
+                "@npmcli/metavuln-calculator": "^9.0.3",
+                "@npmcli/package-json": "^7.0.5",
+                "@npmcli/promise-spawn": "^9.0.1",
+                "@npmcli/redact": "^4.0.0",
+                "@npmcli/run-script": "^10.0.4",
+                "@sigstore/tuf": "^4.0.2",
+                "abbrev": "^4.0.0",
+                "archy": "~1.0.0",
+                "cacache": "^20.0.4",
+                "chalk": "^5.6.2",
+                "ci-info": "^4.4.0",
+                "fastest-levenshtein": "^1.0.16",
+                "fs-minipass": "^3.0.3",
+                "glob": "^13.0.6",
+                "graceful-fs": "^4.2.11",
+                "hosted-git-info": "^9.0.3",
+                "ini": "^6.0.0",
+                "init-package-json": "^8.2.5",
+                "is-cidr": "^6.0.4",
+                "json-parse-even-better-errors": "^5.0.0",
+                "libnpmaccess": "^10.0.3",
+                "libnpmdiff": "^8.1.12",
+                "libnpmexec": "^10.3.2",
+                "libnpmfund": "^7.0.26",
+                "libnpmorg": "^8.0.1",
+                "libnpmpack": "^9.1.12",
+                "libnpmpublish": "^11.2.0",
+                "libnpmsearch": "^9.0.1",
+                "libnpmteam": "^8.0.2",
+                "libnpmversion": "^8.0.4",
+                "make-fetch-happen": "^15.0.6",
+                "minimatch": "^10.2.5",
+                "minipass": "^7.1.3",
+                "minipass-pipeline": "^1.2.4",
+                "ms": "^2.1.2",
+                "node-gyp": "^12.4.0",
+                "nopt": "^9.0.0",
+                "npm-audit-report": "^7.0.0",
+                "npm-install-checks": "^8.0.0",
+                "npm-package-arg": "^13.0.2",
+                "npm-pick-manifest": "^11.0.3",
+                "npm-profile": "^12.0.2",
+                "npm-registry-fetch": "^19.1.1",
+                "npm-user-validate": "^4.0.0",
+                "p-map": "^7.0.4",
+                "pacote": "^21.5.1",
+                "parse-conflict-json": "^5.0.1",
+                "proc-log": "^6.1.0",
+                "qrcode-terminal": "^0.12.0",
+                "read": "^5.0.1",
+                "semver": "^7.8.5",
+                "spdx-expression-parse": "^4.0.0",
+                "ssri": "^13.0.1",
+                "supports-color": "^10.2.2",
+                "tar": "^7.5.19",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^2.0.2",
+                "treeverse": "^3.0.0",
+                "validate-npm-package-name": "^7.0.2",
+                "which": "^6.0.1"
+            },
+            "bin": {
+                "npm": "bin/npm-cli.js",
+                "npx": "bin/npx-cli.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/@gar/promise-retry": {
+            "version": "1.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+            "version": "1.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/@npmcli/agent": {
+            "version": "4.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/arborist": {
+            "version": "9.9.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/fs": "^5.0.0",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "@npmcli/map-workspaces": "^5.0.0",
+                "@npmcli/metavuln-calculator": "^9.0.2",
+                "@npmcli/name-from-folder": "^4.0.0",
+                "@npmcli/node-gyp": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/query": "^5.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "bin-links": "^6.0.0",
+                "cacache": "^20.0.1",
+                "common-ancestor-path": "^2.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-stringify-nice": "^1.1.4",
+                "lru-cache": "^11.2.1",
+                "minimatch": "^10.0.3",
+                "nopt": "^9.0.0",
+                "npm-install-checks": "^8.0.0",
+                "npm-package-arg": "^13.0.0",
+                "npm-pick-manifest": "^11.0.1",
+                "npm-registry-fetch": "^19.0.0",
+                "pacote": "^21.0.2",
+                "parse-conflict-json": "^5.0.1",
+                "proc-log": "^6.0.0",
+                "proggy": "^4.0.0",
+                "promise-all-reject-late": "^1.0.0",
+                "promise-call-limit": "^3.0.1",
+                "semver": "^7.3.7",
+                "ssri": "^13.0.0",
+                "treeverse": "^3.0.0",
+                "walk-up-path": "^4.0.0"
+            },
+            "bin": {
+                "arborist": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/config": {
+            "version": "10.12.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/map-workspaces": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "ci-info": "^4.0.0",
+                "ini": "^6.0.0",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "walk-up-path": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-bundled": "^5.0.0",
+                "npm-normalize-package-bin": "^5.0.0"
+            },
+            "bin": {
+                "installed-package-contents": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+            "version": "5.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/name-from-folder": "^4.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "glob": "^13.0.0",
+                "minimatch": "^10.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+            "version": "9.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cacache": "^20.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "pacote": "^21.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/node-gyp": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/query": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/redact": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/run-script": {
+            "version": "10.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/node-gyp": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "node-gyp": "^12.1.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/bundle": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/core": {
+            "version": "3.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+            "version": "0.5.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/sign": {
+            "version": "4.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.2",
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.0",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "make-fetch-happen": "^15.0.4",
+                "proc-log": "^6.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/tuf": {
+            "version": "4.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "tuf-js": "^4.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/verify": {
+            "version": "3.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.1",
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@tufjs/canonical-json": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@tufjs/models": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "2.0.0",
+                "minimatch": "^10.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/abbrev": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/agent-base": {
+            "version": "7.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/aproba": {
+            "version": "2.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/archy": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/bin-links": {
+            "version": "6.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cmd-shim": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "read-cmd-shim": "^6.0.0",
+                "write-file-atomic": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/binary-extensions": {
+            "version": "3.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/cacache": {
+            "version": "20.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/chalk": {
+            "version": "5.6.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/chownr": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/ci-info": {
+            "version": "4.4.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/cidr-regex": {
+            "version": "5.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/npm/node_modules/cmd-shim": {
+            "version": "8.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/common-ancestor-path": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/cssesc": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/debug": {
+            "version": "4.4.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/npm/node_modules/diff": {
+            "version": "8.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/env-paths": {
+            "version": "2.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/exponential-backoff": {
+            "version": "3.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/npm/node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
+        },
+        "node_modules/npm/node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/glob": {
+            "version": "13.0.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/npm/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/npm/node_modules/ignore-walk": {
+            "version": "8.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minimatch": "^10.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/ini": {
+            "version": "6.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/init-package-json": {
+            "version": "8.2.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/package-json": "^7.0.0",
+                "npm-package-arg": "^13.0.0",
+                "promzard": "^3.0.1",
+                "read": "^5.0.1",
+                "semver": "^7.7.2",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/ip-address": {
+            "version": "10.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/npm/node_modules/is-cidr": {
+            "version": "6.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "cidr-regex": "^5.0.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/npm/node_modules/isexe": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/npm/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/json-stringify-nice": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/jsonparse": {
+            "version": "1.3.1",
+            "dev": true,
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/just-diff": {
+            "version": "6.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/just-diff-apply": {
+            "version": "5.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/libnpmaccess": {
+            "version": "10.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-package-arg": "^13.0.0",
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmdiff": {
+            "version": "8.1.12",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^9.9.1",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "binary-extensions": "^3.0.0",
+                "diff": "^8.0.2",
+                "minimatch": "^10.0.3",
+                "npm-package-arg": "^13.0.0",
+                "pacote": "^21.0.2",
+                "tar": "^7.5.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmexec": {
+            "version": "10.3.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/arborist": "^9.9.1",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "ci-info": "^4.0.0",
+                "npm-package-arg": "^13.0.0",
+                "pacote": "^21.0.2",
+                "proc-log": "^6.0.0",
+                "read": "^5.0.1",
+                "semver": "^7.3.7",
+                "signal-exit": "^4.1.0",
+                "walk-up-path": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmfund": {
+            "version": "7.0.26",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^9.9.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmorg": {
+            "version": "8.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpack": {
+            "version": "9.1.12",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^9.9.1",
+                "@npmcli/run-script": "^10.0.0",
+                "npm-package-arg": "^13.0.0",
+                "pacote": "^21.0.2"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpublish": {
+            "version": "11.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/package-json": "^7.0.0",
+                "ci-info": "^4.0.0",
+                "npm-package-arg": "^13.0.0",
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.7",
+                "sigstore": "^4.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmsearch": {
+            "version": "9.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmteam": {
+            "version": "8.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmversion": {
+            "version": "8.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/make-fetch-happen": {
+            "version": "15.0.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/minimatch": {
+            "version": "10.2.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/minipass": {
+            "version": "7.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-fetch": {
+            "version": "5.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush": {
+            "version": "1.0.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minipass": "^7.1.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minipass-sized": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minizlib": {
+            "version": "3.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/ms": {
+            "version": "2.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/mute-stream": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/negotiator": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp": {
+            "version": "12.4.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
+                "graceful-fs": "^4.2.6",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "tar": "^7.5.4",
+                "tinyglobby": "^0.2.12",
+                "undici": "^6.25.0",
+                "which": "^6.0.0"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/nopt": {
+            "version": "9.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^4.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-audit-report": {
+            "version": "7.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-bundled": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-normalize-package-bin": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-install-checks": {
+            "version": "8.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-normalize-package-bin": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-package-arg": {
+            "version": "13.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-packlist": {
+            "version": "10.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ignore-walk": "^8.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-profile": {
+            "version": "12.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-registry-fetch": {
+            "version": "19.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/redact": "^4.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^15.0.0",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^13.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-user-validate": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/p-map": {
+            "version": "7.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/pacote": {
+            "version": "21.5.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/git": "^7.0.0",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "cacache": "^20.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^7.0.2",
+                "npm-package-arg": "^13.0.0",
+                "npm-packlist": "^10.0.1",
+                "npm-pick-manifest": "^11.0.1",
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0",
+                "sigstore": "^4.0.0",
+                "ssri": "^13.0.0",
+                "tar": "^7.4.3"
+            },
+            "bin": {
+                "pacote": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/parse-conflict-json": {
+            "version": "5.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^5.0.0",
+                "just-diff": "^6.0.0",
+                "just-diff-apply": "^5.2.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/postcss-selector-parser": {
+            "version": "7.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/proc-log": {
+            "version": "6.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/proggy": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/promise-all-reject-late": {
+            "version": "1.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/promise-call-limit": {
+            "version": "3.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/promzard": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "read": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/qrcode-terminal": {
+            "version": "0.12.0",
+            "dev": true,
+            "inBundle": true,
+            "bin": {
+                "qrcode-terminal": "bin/qrcode-terminal.js"
+            }
+        },
+        "node_modules/npm/node_modules/read": {
+            "version": "5.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "mute-stream": "^3.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/read-cmd-shim": {
+            "version": "6.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/npm/node_modules/semver": {
+            "version": "7.8.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore": {
+            "version": "4.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.1",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "@sigstore/sign": "^4.1.1",
+                "@sigstore/tuf": "^4.0.2",
+                "@sigstore/verify": "^3.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks": {
+            "version": "2.8.9",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "^10.1.1",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/npm/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "dev": true,
+            "inBundle": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/npm/node_modules/ssri": {
+            "version": "13.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/supports-color": {
+            "version": "10.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/tar": {
+            "version": "7.5.19",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/text-table": {
+            "version": "0.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tiny-relative-date": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/npm/node_modules/treeverse": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/tuf-js": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/models": "4.1.0",
+                "debug": "^4.4.3",
+                "make-fetch-happen": "^15.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/undici": {
+            "version": "6.27.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
+        "node_modules/npm/node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/walk-up-path": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/which": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/write-file-atomic": {
+            "version": "7.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/yallist": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/object-assign": {
@@ -1774,11 +5616,72 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
+        },
+        "node_modules/p-each-series": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+            "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-filter": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+            "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-map": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
@@ -1810,11 +5713,73 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-map": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-reduce": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+            "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/parents": {
             "version": "1.0.1",
@@ -1837,6 +5802,61 @@
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
             }
+        },
+        "node_modules/parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-ms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+            "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+            "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^6.0.1"
+            }
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/path-browserify": {
             "version": "1.0.1",
@@ -1862,6 +5882,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -1875,6 +5908,16 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/pbkdf2": {
@@ -1894,6 +5937,13 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/picomatch": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -1907,6 +5957,93 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pkg-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pkg-conf/node_modules/find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pkg-conf/node_modules/locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pkg-conf/node_modules/p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pkg-conf/node_modules/p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pkg-conf/node_modules/path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -1914,6 +6051,22 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/pretty-ms": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-ms": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/process": {
@@ -1930,6 +6083,31 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
+        },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "kerberos": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "kerberos": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/public-encrypt": {
             "version": "4.0.3",
@@ -1995,6 +6173,32 @@
                 "safe-buffer": "^5.1.0"
             }
         },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/read-only-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -2002,6 +6206,141 @@
             "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/read-package-up": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+            "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.0",
+                "read-pkg": "^9.0.0",
+                "type-fest": "^4.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-package-up/node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/read-package-up/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/read-package-up/node_modules/normalize-package-data": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/read-package-up/node_modules/read-pkg": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.3",
+                "normalize-package-data": "^6.0.0",
+                "parse-json": "^8.0.0",
+                "type-fest": "^4.6.0",
+                "unicorn-magic": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-package-up/node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+            "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.4",
+                "normalize-package-data": "^8.0.0",
+                "parse-json": "^8.3.0",
+                "type-fest": "^5.4.4",
+                "unicorn-magic": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "dependencies": {
+                "tagged-tag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/unicorn-magic": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/readable-stream": {
@@ -2046,6 +6385,19 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/registry-auth-token": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+            "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pnpm/npm-conf": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2066,6 +6418,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ripemd160": {
@@ -2106,6 +6468,342 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "node_modules/semantic-release": {
+            "version": "25.0.9",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
+            "integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@semantic-release/commit-analyzer": "^13.0.1",
+                "@semantic-release/error": "^4.0.0",
+                "@semantic-release/github": "^12.0.0",
+                "@semantic-release/npm": "^13.1.1",
+                "@semantic-release/release-notes-generator": "^14.1.0",
+                "aggregate-error": "^5.0.0",
+                "cosmiconfig": "^9.0.0",
+                "debug": "^4.0.0",
+                "env-ci": "^11.0.0",
+                "execa": "^9.0.0",
+                "figures": "^6.0.0",
+                "find-versions": "^6.0.0",
+                "get-stream": "^6.0.0",
+                "git-log-parser": "^1.2.0",
+                "hook-std": "^4.0.0",
+                "hosted-git-info": "^9.0.0",
+                "import-from-esm": "^2.0.0",
+                "lodash-es": "^4.17.21",
+                "marked": "^15.0.0",
+                "marked-terminal": "^7.3.0",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^3.0.0",
+                "p-reduce": "^3.0.0",
+                "read-package-up": "^12.0.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.3.2",
+                "signale": "^1.2.1",
+                "yargs": "^18.0.0"
+            },
+            "bin": {
+                "semantic-release": "bin/semantic-release.js"
+            },
+            "engines": {
+                "node": "^22.14.0 || >= 24.10.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/ansi-regex": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/semantic-release/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/semantic-release/node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/semantic-release/node_modules/cliui/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/semantic-release/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/read-package-up": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+            "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.1",
+                "read-pkg": "^10.0.0",
+                "type-fest": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/string-width": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/semantic-release/node_modules/type-fest": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "dependencies": {
+                "tagged-tag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/semantic-release/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/yargs": {
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+            "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^8.2.1",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/semantic-release/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/semver-regex": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+            "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/serialize-javascript": {
             "version": "7.1.0",
@@ -2161,6 +6859,29 @@
             "dev": true,
             "dependencies": {
                 "fast-safe-stringify": "^2.0.7"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/shell-quote": {
@@ -2229,6 +6950,125 @@
             "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
             "dev": true
         },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/signale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+            "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^2.3.2",
+                "figures": "^2.0.0",
+                "pkg-conf": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/signale/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/signale/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/signale/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/signale/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/signale/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/signale/node_modules/figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/signale/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/signale/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2249,6 +7089,19 @@
                 }
             ]
         },
+        "node_modules/skin-tone": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "unicode-emoji-modifier-base": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2256,6 +7109,59 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spawn-error-forwarder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/split2": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+            "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "through2": "~2.0.0"
             }
         },
         "node_modules/stream-browserify": {
@@ -2363,6 +7269,29 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2384,6 +7313,24 @@
                 "minimist": "^1.1.0"
             }
         },
+        "node_modules/super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2399,6 +7346,36 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/supports-hyperlinks": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+            }
+        },
+        "node_modules/supports-hyperlinks/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/syntax-error": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
@@ -2406,6 +7383,97 @@
             "dev": true,
             "dependencies": {
                 "acorn-node": "^1.2.0"
+            }
+        },
+        "node_modules/tagged-tag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+            "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/temp-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/tempy": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+            "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-stream": "^3.0.0",
+                "temp-dir": "^3.0.0",
+                "type-fest": "^2.12.2",
+                "unique-string": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tempy/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tempy/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/through": {
@@ -2424,6 +7492,22 @@
                 "xtend": "~4.0.1"
             }
         },
+        "node_modules/time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "convert-hrtime": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/timers-browserify": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
@@ -2434,6 +7518,54 @@
             },
             "engines": {
                 "node": ">=0.6.0"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/to-buffer": {
@@ -2468,11 +7600,47 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/traverse": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+            "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/tty-browserify": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
             "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
             "dev": true
+        },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
@@ -2493,6 +7661,20 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/umd": {
             "version": "3.0.3",
@@ -2519,6 +7701,72 @@
                 "undeclared-identifiers": "bin.js"
             }
         },
+        "node_modules/undici": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
+        "node_modules/unicode-emoji-modifier-base": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/unique-string": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "crypto-random-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -2527,6 +7775,16 @@
             "dependencies": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
+            }
+        },
+        "node_modules/url-join": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+            "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/url/node_modules/punycode": {
@@ -2555,11 +7813,61 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "node_modules/vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
+        },
+        "node_modules/web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/which-command": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+            "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "which-command": "cli.js"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/which-command?sponsor=1"
+            }
         },
         "node_modules/which-typed-array": {
             "version": "1.1.22",
@@ -2581,6 +7889,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/workerpool": {
             "version": "6.5.1",
@@ -2684,9 +7999,427 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/yoctocolors": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         }
     },
     "dependencies": {
+        "@actions/core": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+            "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+            "dev": true,
+            "requires": {
+                "@actions/exec": "^3.0.0",
+                "@actions/http-client": "^4.0.0"
+            }
+        },
+        "@actions/exec": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+            "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+            "dev": true,
+            "requires": {
+                "@actions/io": "^3.0.2"
+            }
+        },
+        "@actions/http-client": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+            "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+            "dev": true,
+            "requires": {
+                "tunnel": "^0.0.6",
+                "undici": "^6.23.0"
+            },
+            "dependencies": {
+                "undici": {
+                    "version": "6.28.0",
+                    "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+                    "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+                    "dev": true
+                }
+            }
+        },
+        "@actions/io": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+            "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+            "dev": true
+        },
+        "@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true
+        },
+        "@colors/colors": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@conventional-changelog/template": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
+            "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
+            "dev": true
+        },
+        "@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "dev": true
+        },
+        "@octokit/core": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+            "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
+            "dev": true,
+            "requires": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.4",
+                "@octokit/request": "^10.0.13",
+                "@octokit/request-error": "^7.1.1",
+                "@octokit/types": "^17.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            }
+        },
+        "@octokit/endpoint": {
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+            "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^17.0.0",
+                "universal-user-agent": "^7.0.2"
+            }
+        },
+        "@octokit/graphql": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+            "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+            "dev": true,
+            "requires": {
+                "@octokit/request": "^10.0.13",
+                "@octokit/types": "^17.0.0",
+                "universal-user-agent": "^7.0.0"
+            }
+        },
+        "@octokit/openapi-types": {
+            "version": "28.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+            "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+            "dev": true
+        },
+        "@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^16.0.0"
+            },
+            "dependencies": {
+                "@octokit/openapi-types": {
+                    "version": "27.0.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+                    "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+                    "dev": true
+                },
+                "@octokit/types": {
+                    "version": "16.0.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+                    "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+                    "dev": true,
+                    "requires": {
+                        "@octokit/openapi-types": "^27.0.0"
+                    }
+                }
+            }
+        },
+        "@octokit/plugin-retry": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
+            "integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
+            "dev": true,
+            "requires": {
+                "@octokit/request-error": "^7.1.1",
+                "@octokit/types": "^17.0.0",
+                "bottleneck": "^2.15.3"
+            }
+        },
+        "@octokit/plugin-throttling": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
+            "integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^17.0.0",
+                "bottleneck": "^2.15.3"
+            }
+        },
+        "@octokit/request": {
+            "version": "10.0.13",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+            "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+            "dev": true,
+            "requires": {
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.1.1",
+                "@octokit/types": "^17.0.0",
+                "content-type": "^2.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
+            }
+        },
+        "@octokit/request-error": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+            "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^17.0.0"
+            }
+        },
+        "@octokit/types": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+            "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+            "dev": true,
+            "requires": {
+                "@octokit/openapi-types": "^28.0.0"
+            }
+        },
+        "@pnpm/config.env-replace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "dev": true
+        },
+        "@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.10"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.2.10",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+                    "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+                    "dev": true
+                }
+            }
+        },
+        "@pnpm/npm-conf": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+            "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+            "dev": true,
+            "requires": {
+                "@pnpm/config.env-replace": "^1.1.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            }
+        },
+        "@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true
+        },
+        "@semantic-release/changelog": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-7.0.0.tgz",
+            "integrity": "sha512-TNPyag5db24o7jWjre7UwKB4EcL8oJxbRhnDQ7hmZRAYqzreAc6PgdxQuU3pppp5xQinYtiumL0iG8SSKvnlzg==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "lodash-es": "^4.17.21"
+            }
+        },
+        "@semantic-release/commit-analyzer": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+            "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "import-from-esm": "^2.0.0",
+                "lodash-es": "^4.17.21",
+                "micromatch": "^4.0.2"
+            }
+        },
+        "@semantic-release/error": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+            "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+            "dev": true
+        },
+        "@semantic-release/git": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-11.0.1.tgz",
+            "integrity": "sha512-Zr8BUYCTZMc8V6wDKN2dpR7nJgewd9I6THL3ydLTnp3OEdTo1/4RBLNYaeRucYMsjMv+BXoCNfXA0NADj1kwhw==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "debug": "^4.0.0",
+                "dir-glob": "^3.0.0",
+                "execa": "^10.0.0",
+                "lodash-es": "^4.17.21",
+                "micromatch": "^4.0.0",
+                "p-reduce": "^3.0.0"
+            }
+        },
+        "@semantic-release/github": {
+            "version": "12.0.9",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.9.tgz",
+            "integrity": "sha512-ODIqb0V3QqndipryEEiaBxUQCFjvv7Oese5Dt4omMGa60YRNEW0Sx3K+zri0uac2Y6S9nOlMehciWIzvvRCTGQ==",
+            "dev": true,
+            "requires": {
+                "@octokit/core": "^7.0.0",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-retry": "^8.0.0",
+                "@octokit/plugin-throttling": "^11.0.0",
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "debug": "^4.3.4",
+                "dir-glob": "^3.0.1",
+                "http-proxy-agent": "^9.0.0",
+                "https-proxy-agent": "^9.0.0",
+                "issue-parser": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "mime": "^4.0.0",
+                "p-filter": "^4.0.0",
+                "tinyglobby": "^0.2.14",
+                "undici": "^7.0.0",
+                "url-join": "^5.0.0"
+            }
+        },
+        "@semantic-release/npm": {
+            "version": "13.1.5",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+            "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
+            "dev": true,
+            "requires": {
+                "@actions/core": "^3.0.0",
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^5.0.0",
+                "env-ci": "^11.2.0",
+                "execa": "^9.0.0",
+                "fs-extra": "^11.0.0",
+                "lodash-es": "^4.17.21",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^9.0.0",
+                "npm": "^11.6.2",
+                "rc": "^1.2.8",
+                "read-pkg": "^10.0.0",
+                "registry-auth-token": "^5.0.0",
+                "semver": "^7.1.2",
+                "tempy": "^3.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "9.6.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+                    "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+                    "dev": true,
+                    "requires": {
+                        "@sindresorhus/merge-streams": "^4.0.0",
+                        "cross-spawn": "^7.0.6",
+                        "figures": "^6.1.0",
+                        "get-stream": "^9.0.0",
+                        "human-signals": "^8.0.1",
+                        "is-plain-obj": "^4.1.0",
+                        "is-stream": "^4.0.1",
+                        "npm-run-path": "^6.0.0",
+                        "pretty-ms": "^9.2.0",
+                        "signal-exit": "^4.1.0",
+                        "strip-final-newline": "^4.0.0",
+                        "yoctocolors": "^2.1.1"
+                    }
+                },
+                "is-plain-obj": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+                    "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+                    "dev": true
+                }
+            }
+        },
+        "@semantic-release/release-notes-generator": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+            "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "import-from-esm": "^2.0.0",
+                "lodash-es": "^4.17.21",
+                "read-package-up": "^11.0.0"
+            }
+        },
+        "@simple-libs/stream-utils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+            "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+            "dev": true
+        },
+        "@sindresorhus/is": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "dev": true
+        },
+        "@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true
+        },
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -2710,11 +8443,36 @@
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
             "dev": true
         },
+        "agent-base": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+            "dev": true
+        },
+        "aggregate-error": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+            "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^5.2.0",
+                "indent-string": "^5.0.0"
+            }
+        },
         "ansi-colors": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "dev": true
+        },
+        "ansi-escapes": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "dev": true,
+            "requires": {
+                "environment": "^1.0.0"
+            }
         },
         "ansi-regex": {
             "version": "5.0.1",
@@ -2731,6 +8489,12 @@
                 "color-convert": "^2.0.1"
             }
         },
+        "any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true
+        },
         "anymatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -2745,6 +8509,18 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "argv-formatter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
+            "dev": true
+        },
+        "array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
             "dev": true
         },
         "asn1.js": {
@@ -2815,6 +8591,12 @@
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
         },
+        "before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true
+        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2825,6 +8607,12 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
             "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+            "dev": true
+        },
+        "bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
             "dev": true
         },
         "brace-expansion": {
@@ -3088,6 +8876,12 @@
                 "get-intrinsic": "^1.3.0"
             }
         },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
         "camelcase": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -3115,6 +8909,12 @@
                 }
             }
         },
+        "char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
+        },
         "chokidar": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -3140,6 +8940,47 @@
                 "inherits": "^2.0.4",
                 "safe-buffer": "^5.2.1",
                 "to-buffer": "^1.2.2"
+            }
+        },
+        "clean-stack": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+            "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "5.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+                    "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+                    "dev": true
+                }
+            }
+        },
+        "cli-highlight": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+            "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0",
+                "highlight.js": "^10.7.1",
+                "mz": "^2.4.0",
+                "parse5": "^5.1.1",
+                "parse5-htmlparser2-tree-adapter": "^6.0.0",
+                "yargs": "^16.0.0"
+            }
+        },
+        "cli-table3": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+            "dev": true,
+            "requires": {
+                "@colors/colors": "1.5.0",
+                "string-width": "^4.2.0"
             }
         },
         "cliui": {
@@ -3180,6 +9021,16 @@
                 "source-map": "~0.5.3"
             }
         },
+        "compare-func": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+            "dev": true,
+            "requires": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^5.1.0"
+            }
+        },
         "concat-stream": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -3190,6 +9041,16 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.2.2",
                 "typedarray": "^0.0.6"
+            }
+        },
+        "config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
             }
         },
         "console-browserify": {
@@ -3204,6 +9065,65 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
+        "content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true
+        },
+        "conventional-changelog-angular": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+            "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+            "dev": true,
+            "requires": {
+                "compare-func": "^2.0.0"
+            }
+        },
+        "conventional-changelog-conventionalcommits": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
+            "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
+            "dev": true,
+            "requires": {
+                "@conventional-changelog/template": "^1.3.0"
+            }
+        },
+        "conventional-changelog-writer": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+            "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+            "dev": true,
+            "requires": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            }
+        },
+        "conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "dev": true
+        },
+        "conventional-commits-parser": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+            "dev": true,
+            "requires": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "meow": "^13.0.0"
+            }
+        },
+        "convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+            "dev": true
+        },
         "convert-source-map": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
@@ -3215,6 +9135,32 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
+        },
+        "cosmiconfig": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+            "dev": true,
+            "requires": {
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+                    "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-even-better-errors": "^2.3.0",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                }
+            }
         },
         "create-ecdh": {
             "version": "4.0.4",
@@ -3261,6 +9207,25 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                }
+            }
+        },
         "crypto-browserify": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -3278,6 +9243,23 @@
                 "public-encrypt": "^4.0.0",
                 "randombytes": "^2.0.0",
                 "randomfill": "^1.0.3"
+            }
+        },
+        "crypto-random-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+            "dev": true,
+            "requires": {
+                "type-fest": "^1.0.1"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+                    "dev": true
+                }
             }
         },
         "dash-ast": {
@@ -3299,6 +9281,12 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true
         },
         "define-data-property": {
@@ -3376,11 +9364,29 @@
                 }
             }
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            }
+        },
         "domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
+        },
+        "dot-prop": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "dev": true,
+            "requires": {
+                "is-obj": "^2.0.0"
+            }
         },
         "dunder-proto": {
             "version": "1.0.1",
@@ -3430,6 +9436,95 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "emojilib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+            "dev": true
+        },
+        "env-ci": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+            "integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
+            "dev": true,
+            "requires": {
+                "execa": "^8.0.0",
+                "java-properties": "^1.0.2"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+                    "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^8.0.1",
+                        "human-signals": "^5.0.0",
+                        "is-stream": "^3.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^5.1.0",
+                        "onetime": "^6.0.0",
+                        "signal-exit": "^4.1.0",
+                        "strip-final-newline": "^3.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+                    "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+                    "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+                    "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^4.0.0"
+                    }
+                },
+                "strip-final-newline": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+                    "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+                    "dev": true
+                }
+            }
+        },
+        "env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true
+        },
+        "environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
         },
         "es-define-property": {
             "version": "1.0.1",
@@ -3486,11 +9581,56 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "execa": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
+            "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
+            "dev": true,
+            "requires": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.1",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.3.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "which-command": "^0.1.0",
+                "yoctocolors": "^2.1.2"
+            },
+            "dependencies": {
+                "is-plain-obj": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+                    "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+                    "dev": true
+                }
+            }
+        },
         "fast-safe-stringify": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
             "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
             "dev": true
+        },
+        "figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "dev": true,
+            "requires": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "dependencies": {
+                "is-unicode-supported": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+                    "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+                    "dev": true
+                }
+            }
         },
         "fill-range": {
             "version": "7.1.1",
@@ -3511,6 +9651,22 @@
                 "path-exists": "^4.0.0"
             }
         },
+        "find-up-simple": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+            "dev": true
+        },
+        "find-versions": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+            "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+            "dev": true,
+            "requires": {
+                "semver-regex": "^4.0.5",
+                "super-regex": "^1.0.0"
+            }
+        },
         "flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -3524,6 +9680,17 @@
             "dev": true,
             "requires": {
                 "is-callable": "^1.2.7"
+            }
+        },
+        "fs-extra": {
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+            "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             }
         },
         "fs.realpath": {
@@ -3545,6 +9712,12 @@
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true
         },
+        "function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "dev": true
+        },
         "get-assigned-identifiers": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
@@ -3555,6 +9728,12 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
             "dev": true
         },
         "get-intrinsic": {
@@ -3585,6 +9764,30 @@
                 "es-object-atoms": "^1.0.0"
             }
         },
+        "get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "requires": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            }
+        },
+        "git-log-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
+            "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
+            "dev": true,
+            "requires": {
+                "argv-formatter": "~1.0.0",
+                "spawn-error-forwarder": "~1.0.0",
+                "split2": "~1.0.0",
+                "stream-combiner2": "~1.1.1",
+                "through2": "~2.0.0",
+                "traverse": "0.6.8"
+            }
+        },
         "glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -3613,6 +9816,33 @@
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
         },
         "has": {
             "version": "1.0.3",
@@ -3690,6 +9920,12 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
+        "highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "dev": true
+        },
         "hmac-drbg": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3701,11 +9937,37 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
+        "hook-std": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-4.0.0.tgz",
+            "integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^11.1.0"
+            }
+        },
         "htmlescape": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
             "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
             "dev": true
+        },
+        "http-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+            "dev": true,
+            "requires": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            }
         },
         "https-browserify": {
             "version": "1.0.0",
@@ -3713,10 +9975,73 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
+        "https-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            }
+        },
+        "human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true
+        },
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "import-from-esm": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+            "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.3.4",
+                "import-meta-resolve": "^4.0.0"
+            }
+        },
+        "import-meta-resolve": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+            "dev": true
+        },
+        "index-to-position": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
             "dev": true
         },
         "inflight": {
@@ -3733,6 +10058,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
         "inline-source-map": {
@@ -3766,6 +10097,12 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
             "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+            "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
         },
         "is-binary-path": {
@@ -3831,10 +10168,22 @@
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
         },
+        "is-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+            "dev": true
+        },
         "is-plain-obj": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
             "dev": true
         },
         "is-typed-array": {
@@ -3858,6 +10207,37 @@
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
         },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
+        "issue-parser": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+            "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
+            "dev": true,
+            "requires": {
+                "lodash.capitalize": "^4.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.uniqby": "^4.7.0"
+            }
+        },
+        "java-properties": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+            "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
         "js-yaml": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -3865,6 +10245,34 @@
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
+        },
+        "json-with-bigint": {
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+            "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
             }
         },
         "jsonparse": {
@@ -3893,6 +10301,36 @@
                 "stream-splicer": "^2.0.0"
             }
         },
+        "lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                }
+            }
+        },
         "locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3902,10 +10340,46 @@
                 "p-locate": "^5.0.0"
             }
         },
+        "lodash-es": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+            "dev": true
+        },
+        "lodash.capitalize": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+            "dev": true
+        },
+        "lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+            "dev": true
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true
+        },
         "lodash.memoize": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
             "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+            "dev": true
+        },
+        "lodash.uniqby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+            "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
             "dev": true
         },
         "log-symbols": {
@@ -3916,6 +10390,58 @@
             "requires": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
+            }
+        },
+        "lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true
+        },
+        "make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "dev": true,
+            "requires": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            }
+        },
+        "marked": {
+            "version": "15.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+            "dev": true
+        },
+        "marked-terminal": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+            "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^7.0.0",
+                "ansi-regex": "^6.1.0",
+                "chalk": "^5.4.1",
+                "cli-highlight": "^2.1.11",
+                "cli-table3": "^0.6.5",
+                "node-emoji": "^2.2.0",
+                "supports-hyperlinks": "^3.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+                    "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+                    "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+                    "dev": true
+                }
             }
         },
         "math-intrinsics": {
@@ -3935,6 +10461,28 @@
                 "safe-buffer": "^5.1.2"
             }
         },
+        "meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "dev": true
+        },
+        "merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            }
+        },
         "miller-rabin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -3952,6 +10500,18 @@
                     "dev": true
                 }
             }
+        },
+        "mime": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+            "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+            "dev": true
+        },
+        "mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true
         },
         "minimalistic-assert": {
             "version": "1.0.1",
@@ -4058,11 +10618,1304 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
+        "mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "requires": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
+        "neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "nerf-dart": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+            "dev": true
+        },
+        "node-emoji": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+            "dev": true,
+            "requires": {
+                "@sindresorhus/is": "^4.6.0",
+                "char-regex": "^1.0.2",
+                "emojilib": "^2.4.0",
+                "skin-tone": "^2.0.0"
+            }
+        },
+        "normalize-package-data": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+            "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^9.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            }
+        },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
+        },
+        "normalize-url": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+            "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
+            "dev": true
+        },
+        "npm": {
+            "version": "11.19.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
+            "integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
+            "dev": true,
+            "requires": {
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/arborist": "^9.9.1",
+                "@npmcli/config": "^10.12.0",
+                "@npmcli/fs": "^5.0.0",
+                "@npmcli/map-workspaces": "^5.0.3",
+                "@npmcli/metavuln-calculator": "^9.0.3",
+                "@npmcli/package-json": "^7.0.5",
+                "@npmcli/promise-spawn": "^9.0.1",
+                "@npmcli/redact": "^4.0.0",
+                "@npmcli/run-script": "^10.0.4",
+                "@sigstore/tuf": "^4.0.2",
+                "abbrev": "^4.0.0",
+                "archy": "~1.0.0",
+                "cacache": "^20.0.4",
+                "chalk": "^5.6.2",
+                "ci-info": "^4.4.0",
+                "fastest-levenshtein": "^1.0.16",
+                "fs-minipass": "^3.0.3",
+                "glob": "^13.0.6",
+                "graceful-fs": "^4.2.11",
+                "hosted-git-info": "^9.0.3",
+                "ini": "^6.0.0",
+                "init-package-json": "^8.2.5",
+                "is-cidr": "^6.0.4",
+                "json-parse-even-better-errors": "^5.0.0",
+                "libnpmaccess": "^10.0.3",
+                "libnpmdiff": "^8.1.12",
+                "libnpmexec": "^10.3.2",
+                "libnpmfund": "^7.0.26",
+                "libnpmorg": "^8.0.1",
+                "libnpmpack": "^9.1.12",
+                "libnpmpublish": "^11.2.0",
+                "libnpmsearch": "^9.0.1",
+                "libnpmteam": "^8.0.2",
+                "libnpmversion": "^8.0.4",
+                "make-fetch-happen": "^15.0.6",
+                "minimatch": "^5.1.9",
+                "minipass": "^7.1.3",
+                "minipass-pipeline": "^1.2.4",
+                "ms": "^2.1.2",
+                "node-gyp": "^12.4.0",
+                "nopt": "^9.0.0",
+                "npm-audit-report": "^7.0.0",
+                "npm-install-checks": "^8.0.0",
+                "npm-package-arg": "^13.0.2",
+                "npm-pick-manifest": "^11.0.3",
+                "npm-profile": "^12.0.2",
+                "npm-registry-fetch": "^19.1.1",
+                "npm-user-validate": "^4.0.0",
+                "p-map": "^7.0.4",
+                "pacote": "^21.5.1",
+                "parse-conflict-json": "^5.0.1",
+                "proc-log": "^6.1.0",
+                "qrcode-terminal": "^0.12.0",
+                "read": "^5.0.1",
+                "semver": "^7.8.5",
+                "spdx-expression-parse": "^4.0.0",
+                "ssri": "^13.0.1",
+                "supports-color": "^10.2.2",
+                "tar": "^7.5.19",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^2.0.2",
+                "treeverse": "^3.0.0",
+                "validate-npm-package-name": "^7.0.2",
+                "which": "^6.0.1"
+            },
+            "dependencies": {
+                "@gar/promise-retry": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@isaacs/fs-minipass": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.0.4"
+                    }
+                },
+                "@isaacs/string-locale-compare": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@npmcli/agent": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^7.1.0",
+                        "http-proxy-agent": "^7.0.0",
+                        "https-proxy-agent": "^7.0.1",
+                        "lru-cache": "^11.2.1",
+                        "socks-proxy-agent": "^8.0.3"
+                    }
+                },
+                "@npmcli/arborist": {
+                    "version": "9.9.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@gar/promise-retry": "^1.0.0",
+                        "@isaacs/string-locale-compare": "^1.1.0",
+                        "@npmcli/fs": "^5.0.0",
+                        "@npmcli/installed-package-contents": "^4.0.0",
+                        "@npmcli/map-workspaces": "^5.0.0",
+                        "@npmcli/metavuln-calculator": "^9.0.2",
+                        "@npmcli/name-from-folder": "^4.0.0",
+                        "@npmcli/node-gyp": "^5.0.0",
+                        "@npmcli/package-json": "^7.0.0",
+                        "@npmcli/query": "^5.0.0",
+                        "@npmcli/redact": "^4.0.0",
+                        "@npmcli/run-script": "^10.0.0",
+                        "bin-links": "^6.0.0",
+                        "cacache": "^20.0.1",
+                        "common-ancestor-path": "^2.0.0",
+                        "hosted-git-info": "^9.0.0",
+                        "json-stringify-nice": "^1.1.4",
+                        "lru-cache": "^11.2.1",
+                        "minimatch": "^5.1.9",
+                        "nopt": "^9.0.0",
+                        "npm-install-checks": "^8.0.0",
+                        "npm-package-arg": "^13.0.0",
+                        "npm-pick-manifest": "^11.0.1",
+                        "npm-registry-fetch": "^19.0.0",
+                        "pacote": "^21.0.2",
+                        "parse-conflict-json": "^5.0.1",
+                        "proc-log": "^6.0.0",
+                        "proggy": "^4.0.0",
+                        "promise-all-reject-late": "^1.0.0",
+                        "promise-call-limit": "^3.0.1",
+                        "semver": "^7.3.7",
+                        "ssri": "^13.0.0",
+                        "treeverse": "^3.0.0",
+                        "walk-up-path": "^4.0.0"
+                    }
+                },
+                "@npmcli/config": {
+                    "version": "10.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/map-workspaces": "^5.0.0",
+                        "@npmcli/package-json": "^7.0.0",
+                        "ci-info": "^4.0.0",
+                        "ini": "^6.0.0",
+                        "nopt": "^9.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.5",
+                        "walk-up-path": "^4.0.0"
+                    }
+                },
+                "@npmcli/fs": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^7.3.5"
+                    }
+                },
+                "@npmcli/git": {
+                    "version": "7.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@gar/promise-retry": "^1.0.0",
+                        "@npmcli/promise-spawn": "^9.0.0",
+                        "ini": "^6.0.0",
+                        "lru-cache": "^11.2.1",
+                        "npm-pick-manifest": "^11.0.1",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.5",
+                        "which": "^6.0.0"
+                    }
+                },
+                "@npmcli/installed-package-contents": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-bundled": "^5.0.0",
+                        "npm-normalize-package-bin": "^5.0.0"
+                    }
+                },
+                "@npmcli/map-workspaces": {
+                    "version": "5.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/name-from-folder": "^4.0.0",
+                        "@npmcli/package-json": "^7.0.0",
+                        "glob": "^13.0.0",
+                        "minimatch": "^5.1.9"
+                    }
+                },
+                "@npmcli/metavuln-calculator": {
+                    "version": "9.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cacache": "^20.0.0",
+                        "json-parse-even-better-errors": "^5.0.0",
+                        "pacote": "^21.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "@npmcli/name-from-folder": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@npmcli/node-gyp": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@npmcli/package-json": {
+                    "version": "7.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/git": "^7.0.0",
+                        "glob": "^13.0.0",
+                        "hosted-git-info": "^9.0.0",
+                        "json-parse-even-better-errors": "^5.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.5.3",
+                        "spdx-expression-parse": "^4.0.0"
+                    }
+                },
+                "@npmcli/promise-spawn": {
+                    "version": "9.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "which": "^6.0.0"
+                    }
+                },
+                "@npmcli/query": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "postcss-selector-parser": "^7.0.0"
+                    }
+                },
+                "@npmcli/redact": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@npmcli/run-script": {
+                    "version": "10.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/node-gyp": "^5.0.0",
+                        "@npmcli/package-json": "^7.0.0",
+                        "@npmcli/promise-spawn": "^9.0.0",
+                        "node-gyp": "^12.1.0",
+                        "proc-log": "^6.0.0"
+                    }
+                },
+                "@sigstore/bundle": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@sigstore/protobuf-specs": "^0.5.0"
+                    }
+                },
+                "@sigstore/core": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@sigstore/protobuf-specs": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@sigstore/sign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@gar/promise-retry": "^1.0.2",
+                        "@sigstore/bundle": "^4.0.0",
+                        "@sigstore/core": "^3.2.0",
+                        "@sigstore/protobuf-specs": "^0.5.0",
+                        "make-fetch-happen": "^15.0.4",
+                        "proc-log": "^6.1.0"
+                    }
+                },
+                "@sigstore/tuf": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@sigstore/protobuf-specs": "^0.5.0",
+                        "tuf-js": "^4.1.0"
+                    }
+                },
+                "@sigstore/verify": {
+                    "version": "3.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@sigstore/bundle": "^4.0.0",
+                        "@sigstore/core": "^3.2.1",
+                        "@sigstore/protobuf-specs": "^0.5.0"
+                    }
+                },
+                "@tufjs/canonical-json": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@tufjs/models": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@tufjs/canonical-json": "2.0.0",
+                        "minimatch": "^5.1.9"
+                    }
+                },
+                "abbrev": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "agent-base": {
+                    "version": "7.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "4.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bin-links": {
+                    "version": "6.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cmd-shim": "^8.0.0",
+                        "npm-normalize-package-bin": "^5.0.0",
+                        "proc-log": "^6.0.0",
+                        "read-cmd-shim": "^6.0.0",
+                        "write-file-atomic": "^7.0.0"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "5.0.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^4.0.2"
+                    }
+                },
+                "cacache": {
+                    "version": "20.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/fs": "^5.0.0",
+                        "fs-minipass": "^3.0.0",
+                        "glob": "^13.0.0",
+                        "lru-cache": "^11.1.0",
+                        "minipass": "^7.0.3",
+                        "minipass-collect": "^2.0.1",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "p-map": "^7.0.2",
+                        "ssri": "^13.0.0"
+                    }
+                },
+                "chalk": {
+                    "version": "5.6.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "chownr": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ci-info": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cidr-regex": {
+                    "version": "5.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cmd-shim": {
+                    "version": "8.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "common-ancestor-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cssesc": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.4.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.3"
+                    }
+                },
+                "diff": {
+                    "version": "8.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "env-paths": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "exponential-backoff": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fastest-levenshtein": {
+                    "version": "1.0.16",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fs-minipass": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.0.3"
+                    }
+                },
+                "glob": {
+                    "version": "13.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimatch": "^5.1.9",
+                        "minipass": "^7.1.3",
+                        "path-scurry": "^2.0.2"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hosted-git-info": {
+                    "version": "9.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^11.1.0"
+                    }
+                },
+                "http-cache-semantics": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-proxy-agent": {
+                    "version": "7.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^7.1.0",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^7.1.2",
+                        "debug": "4"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.7.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "8.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimatch": "^5.1.9"
+                    }
+                },
+                "ini": {
+                    "version": "6.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "init-package-json": {
+                    "version": "8.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/package-json": "^7.0.0",
+                        "npm-package-arg": "^13.0.0",
+                        "promzard": "^3.0.1",
+                        "read": "^5.0.1",
+                        "semver": "^7.7.2",
+                        "validate-npm-package-name": "^7.0.0"
+                    }
+                },
+                "ip-address": {
+                    "version": "10.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-cidr": {
+                    "version": "6.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cidr-regex": "^5.0.4"
+                    }
+                },
+                "isexe": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-parse-even-better-errors": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-stringify-nice": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsonparse": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "just-diff": {
+                    "version": "6.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "just-diff-apply": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "libnpmaccess": {
+                    "version": "10.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-package-arg": "^13.0.0",
+                        "npm-registry-fetch": "^19.0.0"
+                    }
+                },
+                "libnpmdiff": {
+                    "version": "8.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/arborist": "^9.9.1",
+                        "@npmcli/installed-package-contents": "^4.0.0",
+                        "binary-extensions": "^3.0.0",
+                        "diff": "^8.0.2",
+                        "minimatch": "^5.1.9",
+                        "npm-package-arg": "^13.0.0",
+                        "pacote": "^21.0.2",
+                        "tar": "^7.5.1"
+                    }
+                },
+                "libnpmexec": {
+                    "version": "10.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@gar/promise-retry": "^1.0.0",
+                        "@npmcli/arborist": "^9.9.1",
+                        "@npmcli/package-json": "^7.0.0",
+                        "@npmcli/run-script": "^10.0.0",
+                        "ci-info": "^4.0.0",
+                        "npm-package-arg": "^13.0.0",
+                        "pacote": "^21.0.2",
+                        "proc-log": "^6.0.0",
+                        "read": "^5.0.1",
+                        "semver": "^7.3.7",
+                        "signal-exit": "^4.1.0",
+                        "walk-up-path": "^4.0.0"
+                    }
+                },
+                "libnpmfund": {
+                    "version": "7.0.26",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/arborist": "^9.9.1"
+                    }
+                },
+                "libnpmorg": {
+                    "version": "8.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "npm-registry-fetch": "^19.0.0"
+                    }
+                },
+                "libnpmpack": {
+                    "version": "9.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/arborist": "^9.9.1",
+                        "@npmcli/run-script": "^10.0.0",
+                        "npm-package-arg": "^13.0.0",
+                        "pacote": "^21.0.2"
+                    }
+                },
+                "libnpmpublish": {
+                    "version": "11.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/package-json": "^7.0.0",
+                        "ci-info": "^4.0.0",
+                        "npm-package-arg": "^13.0.0",
+                        "npm-registry-fetch": "^19.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.7",
+                        "sigstore": "^4.0.0",
+                        "ssri": "^13.0.0"
+                    }
+                },
+                "libnpmsearch": {
+                    "version": "9.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-registry-fetch": "^19.0.0"
+                    }
+                },
+                "libnpmteam": {
+                    "version": "8.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "npm-registry-fetch": "^19.0.0"
+                    }
+                },
+                "libnpmversion": {
+                    "version": "8.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/git": "^7.0.0",
+                        "@npmcli/run-script": "^10.0.0",
+                        "json-parse-even-better-errors": "^5.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.7"
+                    }
+                },
+                "lru-cache": {
+                    "version": "11.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "make-fetch-happen": {
+                    "version": "15.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@gar/promise-retry": "^1.0.0",
+                        "@npmcli/agent": "^4.0.0",
+                        "@npmcli/redact": "^4.0.0",
+                        "cacache": "^20.0.1",
+                        "http-cache-semantics": "^4.1.1",
+                        "minipass": "^7.0.2",
+                        "minipass-fetch": "^5.0.0",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "negotiator": "^1.0.0",
+                        "proc-log": "^6.0.0",
+                        "ssri": "^13.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "10.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^5.0.5"
+                    }
+                },
+                "minipass": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass-collect": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.0.3"
+                    }
+                },
+                "minipass-fetch": {
+                    "version": "5.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "iconv-lite": "^0.7.2",
+                        "minipass": "^7.0.3",
+                        "minipass-sized": "^2.0.0",
+                        "minizlib": "^3.0.1"
+                    }
+                },
+                "minipass-flush": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.1.3"
+                    }
+                },
+                "minipass-pipeline": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "3.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "minipass-sized": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.1.2"
+                    }
+                },
+                "minizlib": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "negotiator": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "node-gyp": {
+                    "version": "12.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "env-paths": "^2.2.0",
+                        "exponential-backoff": "^3.1.1",
+                        "graceful-fs": "^4.2.6",
+                        "nopt": "^9.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.5",
+                        "tar": "^7.5.4",
+                        "tinyglobby": "^0.2.12",
+                        "undici": "^6.25.0",
+                        "which": "^6.0.0"
+                    }
+                },
+                "nopt": {
+                    "version": "9.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "^4.0.0"
+                    }
+                },
+                "npm-audit-report": {
+                    "version": "7.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-bundled": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-normalize-package-bin": "^5.0.0"
+                    }
+                },
+                "npm-install-checks": {
+                    "version": "8.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^7.1.1"
+                    }
+                },
+                "npm-normalize-package-bin": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-package-arg": {
+                    "version": "13.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^9.0.0",
+                        "proc-log": "^6.0.0",
+                        "semver": "^7.3.5",
+                        "validate-npm-package-name": "^7.0.0"
+                    }
+                },
+                "npm-packlist": {
+                    "version": "10.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ignore-walk": "^8.0.0",
+                        "proc-log": "^6.0.0"
+                    }
+                },
+                "npm-pick-manifest": {
+                    "version": "11.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-install-checks": "^8.0.0",
+                        "npm-normalize-package-bin": "^5.0.0",
+                        "npm-package-arg": "^13.0.0",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "npm-profile": {
+                    "version": "12.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-registry-fetch": "^19.0.0",
+                        "proc-log": "^6.1.0"
+                    }
+                },
+                "npm-registry-fetch": {
+                    "version": "19.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/redact": "^4.0.0",
+                        "jsonparse": "^1.3.1",
+                        "make-fetch-happen": "^15.0.0",
+                        "minipass": "^7.0.2",
+                        "minipass-fetch": "^5.0.0",
+                        "minizlib": "^3.0.1",
+                        "npm-package-arg": "^13.0.0",
+                        "proc-log": "^6.0.0"
+                    }
+                },
+                "npm-user-validate": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-map": {
+                    "version": "7.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pacote": {
+                    "version": "21.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@gar/promise-retry": "^1.0.0",
+                        "@npmcli/git": "^7.0.0",
+                        "@npmcli/installed-package-contents": "^4.0.0",
+                        "@npmcli/package-json": "^7.0.0",
+                        "@npmcli/promise-spawn": "^9.0.0",
+                        "@npmcli/run-script": "^10.0.0",
+                        "cacache": "^20.0.0",
+                        "fs-minipass": "^3.0.0",
+                        "minipass": "^7.0.2",
+                        "npm-package-arg": "^13.0.0",
+                        "npm-packlist": "^10.0.1",
+                        "npm-pick-manifest": "^11.0.1",
+                        "npm-registry-fetch": "^19.0.0",
+                        "proc-log": "^6.0.0",
+                        "sigstore": "^4.0.0",
+                        "ssri": "^13.0.0",
+                        "tar": "^7.4.3"
+                    }
+                },
+                "parse-conflict-json": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "json-parse-even-better-errors": "^5.0.0",
+                        "just-diff": "^6.0.0",
+                        "just-diff-apply": "^5.2.0"
+                    }
+                },
+                "path-scurry": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^11.0.0",
+                        "minipass": "^7.1.2"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "7.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                },
+                "proc-log": {
+                    "version": "6.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "proggy": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promise-all-reject-late": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promise-call-limit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promzard": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "read": "^5.0.0"
+                    }
+                },
+                "qrcode-terminal": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "read": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mute-stream": "^3.0.0"
+                    }
+                },
+                "read-cmd-shim": {
+                    "version": "6.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "7.8.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sigstore": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@sigstore/bundle": "^4.0.0",
+                        "@sigstore/core": "^3.2.1",
+                        "@sigstore/protobuf-specs": "^0.5.0",
+                        "@sigstore/sign": "^4.1.1",
+                        "@sigstore/tuf": "^4.0.2",
+                        "@sigstore/verify": "^3.1.1"
+                    }
+                },
+                "smart-buffer": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "socks": {
+                    "version": "2.8.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ip-address": "^10.1.1",
+                        "smart-buffer": "^4.2.0"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "8.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^7.1.2",
+                        "debug": "^4.3.4",
+                        "socks": "^2.8.3"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.23",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ssri": {
+                    "version": "13.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^7.0.3"
+                    }
+                },
+                "supports-color": {
+                    "version": "10.2.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tar": {
+                    "version": "7.5.19",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@isaacs/fs-minipass": "^4.0.0",
+                        "chownr": "^3.0.0",
+                        "minipass": "^7.1.2",
+                        "minizlib": "^3.1.0",
+                        "yallist": "^5.0.0"
+                    }
+                },
+                "text-table": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tiny-relative-date": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tinyglobby": {
+                    "version": "0.2.17",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fdir": "^6.5.0",
+                        "picomatch": "^4.0.4"
+                    },
+                    "dependencies": {
+                        "fdir": {
+                            "version": "6.5.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {}
+                        },
+                        "picomatch": {
+                            "version": "4.0.4",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "treeverse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tuf-js": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@tufjs/models": "4.1.0",
+                        "debug": "^4.4.3",
+                        "make-fetch-happen": "^15.0.1"
+                    }
+                },
+                "undici": {
+                    "version": "6.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "validate-npm-package-name": {
+                    "version": "7.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "walk-up-path": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "which": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^4.0.0"
+                    }
+                },
+                "write-file-atomic": {
+                    "version": "7.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "signal-exit": "^4.0.1"
+                    }
+                },
+                "yallist": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "requires": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            }
         },
         "object-assign": {
             "version": "4.1.1",
@@ -4079,11 +11932,44 @@
                 "wrappy": "1"
             }
         },
+        "onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^4.0.0"
+            }
+        },
         "os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
+        },
+        "p-each-series": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+            "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+            "dev": true
+        },
+        "p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "dev": true,
+            "requires": {
+                "p-timeout": "^6.1.2"
+            }
+        },
+        "p-filter": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+            "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+            "dev": true,
+            "requires": {
+                "p-map": "^7.0.1"
+            }
         },
         "p-limit": {
             "version": "3.1.0",
@@ -4103,11 +11989,44 @@
                 "p-limit": "^3.0.2"
             }
         },
+        "p-map": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+            "dev": true
+        },
+        "p-reduce": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+            "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+            "dev": true
+        },
+        "p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+            "dev": true
+        },
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
         },
         "parents": {
             "version": "1.0.1",
@@ -4131,6 +12050,46 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
+            }
+        },
+        "parse-ms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+            "dev": true
+        },
+        "parse5": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+            "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+            "dev": true
+        },
+        "parse5-htmlparser2-tree-adapter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+            "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+            "dev": true,
+            "requires": {
+                "parse5": "^6.0.1"
+            },
+            "dependencies": {
+                "parse5": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+                    "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+                    "dev": true
+                }
+            }
+        },
         "path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -4149,6 +12108,12 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
+        "path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true
+        },
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4159,6 +12124,12 @@
             "version": "0.11.15",
             "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
             "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
         "pbkdf2": {
@@ -4175,17 +12146,93 @@
                 "to-buffer": "^1.2.2"
             }
         },
+        "picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true
+        },
         "picomatch": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true
         },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true
+        },
+        "pkg-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+                    "dev": true
+                }
+            }
+        },
         "possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
             "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
             "dev": true
+        },
+        "pretty-ms": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+            "dev": true,
+            "requires": {
+                "parse-ms": "^4.0.0"
+            }
         },
         "process": {
             "version": "0.11.10",
@@ -4198,6 +12245,19 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
+        },
+        "proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+            "dev": true,
+            "requires": {}
         },
         "public-encrypt": {
             "version": "4.0.3",
@@ -4258,6 +12318,26 @@
                 "safe-buffer": "^5.1.0"
             }
         },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+                    "dev": true
+                }
+            }
+        },
         "read-only-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -4265,6 +12345,94 @@
             "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
+            }
+        },
+        "read-package-up": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+            "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+            "dev": true,
+            "requires": {
+                "find-up-simple": "^1.0.0",
+                "read-pkg": "^9.0.0",
+                "type-fest": "^4.6.0"
+            },
+            "dependencies": {
+                "hosted-git-info": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+                    "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^10.0.1"
+                    }
+                },
+                "lru-cache": {
+                    "version": "10.4.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+                    "dev": true
+                },
+                "normalize-package-data": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+                    "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^7.0.0",
+                        "semver": "^7.3.5",
+                        "validate-npm-package-license": "^3.0.4"
+                    }
+                },
+                "read-pkg": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+                    "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.3",
+                        "normalize-package-data": "^6.0.0",
+                        "parse-json": "^8.0.0",
+                        "type-fest": "^4.6.0",
+                        "unicorn-magic": "^0.1.0"
+                    }
+                },
+                "unicorn-magic": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+                    "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+            "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+            "dev": true,
+            "requires": {
+                "@types/normalize-package-data": "^2.4.4",
+                "normalize-package-data": "^8.0.0",
+                "parse-json": "^8.3.0",
+                "type-fest": "^5.4.4",
+                "unicorn-magic": "^0.4.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "5.8.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+                    "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+                    "dev": true,
+                    "requires": {
+                        "tagged-tag": "^1.0.0"
+                    }
+                },
+                "unicorn-magic": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+                    "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+                    "dev": true
+                }
             }
         },
         "readable-stream": {
@@ -4308,6 +12476,15 @@
                 "picomatch": "^2.2.1"
             }
         },
+        "registry-auth-token": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+            "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+            "dev": true,
+            "requires": {
+                "@pnpm/npm-conf": "^3.0.2"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4323,6 +12500,12 @@
                 "is-core-module": "^2.0.0",
                 "path-parse": "^1.0.6"
             }
+        },
+        "resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true
         },
         "ripemd160": {
             "version": "2.0.3",
@@ -4344,6 +12527,225 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "semantic-release": {
+            "version": "25.0.9",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
+            "integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/commit-analyzer": "^13.0.1",
+                "@semantic-release/error": "^4.0.0",
+                "@semantic-release/github": "^12.0.0",
+                "@semantic-release/npm": "^13.1.1",
+                "@semantic-release/release-notes-generator": "^14.1.0",
+                "aggregate-error": "^5.0.0",
+                "cosmiconfig": "^9.0.0",
+                "debug": "^4.0.0",
+                "env-ci": "^11.0.0",
+                "execa": "^9.0.0",
+                "figures": "^6.0.0",
+                "find-versions": "^6.0.0",
+                "get-stream": "^6.0.0",
+                "git-log-parser": "^1.2.0",
+                "hook-std": "^4.0.0",
+                "hosted-git-info": "^9.0.0",
+                "import-from-esm": "^2.0.0",
+                "lodash-es": "^4.17.21",
+                "marked": "^15.0.0",
+                "marked-terminal": "^7.3.0",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^3.0.0",
+                "p-reduce": "^3.0.0",
+                "read-package-up": "^12.0.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.3.2",
+                "signale": "^1.2.1",
+                "yargs": "^18.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+                    "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+                    "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+                    "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^7.2.0",
+                        "strip-ansi": "^7.1.0",
+                        "wrap-ansi": "^9.0.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+                            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+                            "dev": true,
+                            "requires": {
+                                "emoji-regex": "^10.3.0",
+                                "get-east-asian-width": "^1.0.0",
+                                "strip-ansi": "^7.1.0"
+                            }
+                        }
+                    }
+                },
+                "emoji-regex": {
+                    "version": "10.6.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+                    "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "9.6.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+                    "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+                    "dev": true,
+                    "requires": {
+                        "@sindresorhus/merge-streams": "^4.0.0",
+                        "cross-spawn": "^7.0.6",
+                        "figures": "^6.1.0",
+                        "get-stream": "^9.0.0",
+                        "human-signals": "^8.0.1",
+                        "is-plain-obj": "^4.1.0",
+                        "is-stream": "^4.0.1",
+                        "npm-run-path": "^6.0.0",
+                        "pretty-ms": "^9.2.0",
+                        "signal-exit": "^4.1.0",
+                        "strip-final-newline": "^4.0.0",
+                        "yoctocolors": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "9.0.1",
+                            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+                            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+                            "dev": true,
+                            "requires": {
+                                "@sec-ant/readable-stream": "^0.4.1",
+                                "is-stream": "^4.0.1"
+                            }
+                        }
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+                    "dev": true
+                },
+                "is-plain-obj": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+                    "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+                    "dev": true
+                },
+                "read-package-up": {
+                    "version": "12.0.0",
+                    "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+                    "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up-simple": "^1.0.1",
+                        "read-pkg": "^10.0.0",
+                        "type-fest": "^5.2.0"
+                    }
+                },
+                "string-width": {
+                    "version": "8.2.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+                    "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+                    "dev": true,
+                    "requires": {
+                        "get-east-asian-width": "^1.5.0",
+                        "strip-ansi": "^7.1.2"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+                    "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^6.2.2"
+                    }
+                },
+                "type-fest": {
+                    "version": "5.8.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+                    "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+                    "dev": true,
+                    "requires": {
+                        "tagged-tag": "^1.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "9.0.2",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+                    "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^6.2.1",
+                        "string-width": "^7.0.0",
+                        "strip-ansi": "^7.1.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+                            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+                            "dev": true,
+                            "requires": {
+                                "emoji-regex": "^10.3.0",
+                                "get-east-asian-width": "^1.0.0",
+                                "strip-ansi": "^7.1.0"
+                            }
+                        }
+                    }
+                },
+                "yargs": {
+                    "version": "18.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+                    "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^9.0.1",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "string-width": "^8.2.1",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^22.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "22.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+                    "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+                    "dev": true
+                }
+            }
+        },
+        "semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true
+        },
+        "semver-regex": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+            "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
             "dev": true
         },
         "serialize-javascript": {
@@ -4385,6 +12787,21 @@
             "requires": {
                 "fast-safe-stringify": "^2.0.7"
             }
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
         },
         "shell-quote": {
             "version": "1.10.0",
@@ -4446,17 +12863,157 @@
             "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
             "dev": true
         },
+        "signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true
+        },
+        "signale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+            "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.2",
+                "figures": "^2.0.0",
+                "pkg-conf": "^2.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+                    "dev": true
+                },
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true
         },
+        "skin-tone": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+            "dev": true,
+            "requires": {
+                "unicode-emoji-modifier-base": "^1.0.0"
+            }
+        },
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
+        },
+        "spawn-error-forwarder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "dev": true
+        },
+        "split2": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+            "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+            "dev": true,
+            "requires": {
+                "through2": "~2.0.0"
+            }
         },
         "stream-browserify": {
             "version": "3.0.0",
@@ -4555,6 +13112,18 @@
                 "ansi-regex": "^5.0.1"
             }
         },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true
+        },
+        "strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true
+        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4570,6 +13139,17 @@
                 "minimist": "^1.1.0"
             }
         },
+        "super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "dev": true,
+            "requires": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            }
+        },
         "supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4579,6 +13159,27 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "supports-hyperlinks": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "syntax-error": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
@@ -4586,6 +13187,62 @@
             "dev": true,
             "requires": {
                 "acorn-node": "^1.2.0"
+            }
+        },
+        "tagged-tag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+            "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+            "dev": true
+        },
+        "temp-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+            "dev": true
+        },
+        "tempy": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+            "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
+            "dev": true,
+            "requires": {
+                "is-stream": "^3.0.0",
+                "temp-dir": "^3.0.0",
+                "type-fest": "^2.12.2",
+                "unique-string": "^3.0.0"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "2.19.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+                    "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+                    "dev": true
+                }
+            }
+        },
+        "thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "dev": true,
+            "requires": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "dev": true,
+            "requires": {
+                "thenify": ">= 3.1.0 < 4"
             }
         },
         "through": {
@@ -4604,6 +13261,15 @@
                 "xtend": "~4.0.1"
             }
         },
+        "time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "dev": true,
+            "requires": {
+                "convert-hrtime": "^5.0.0"
+            }
+        },
         "timers-browserify": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
@@ -4611,6 +13277,31 @@
             "dev": true,
             "requires": {
                 "process": "~0.11.0"
+            }
+        },
+        "tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "requires": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "dependencies": {
+                "fdir": {
+                    "version": "6.5.0",
+                    "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+                    "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+                    "dev": true,
+                    "requires": {}
+                },
+                "picomatch": {
+                    "version": "4.0.5",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+                    "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+                    "dev": true
+                }
             }
         },
         "to-buffer": {
@@ -4641,10 +13332,28 @@
                 "is-number": "^7.0.0"
             }
         },
+        "traverse": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+            "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+            "dev": true
+        },
         "tty-browserify": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
             "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
+        "tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true
+        },
+        "type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true
         },
         "typed-array-buffer": {
@@ -4663,6 +13372,13 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "optional": true
         },
         "umd": {
             "version": "3.0.3",
@@ -4683,6 +13399,45 @@
                 "xtend": "^4.0.1"
             }
         },
+        "undici": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+            "dev": true
+        },
+        "unicode-emoji-modifier-base": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+            "dev": true
+        },
+        "unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true
+        },
+        "unique-string": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+            "dev": true,
+            "requires": {
+                "crypto-random-string": "^4.0.0"
+            }
+        },
+        "universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true
+        },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4700,6 +13455,12 @@
                     "dev": true
                 }
             }
+        },
+        "url-join": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+            "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+            "dev": true
         },
         "util": {
             "version": "0.12.3",
@@ -4721,10 +13482,41 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+            "dev": true
+        },
+        "web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "dev": true
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-command": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+            "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
             "dev": true
         },
         "which-typed-array": {
@@ -4741,6 +13533,12 @@
                 "gopd": "^1.2.0",
                 "has-tostringtag": "^1.0.2"
             }
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
         },
         "workerpool": {
             "version": "6.5.1",
@@ -4814,6 +13612,12 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
+        },
+        "yoctocolors": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -36,12 +36,21 @@
     "main": "./index",
     "scripts": {
         "start": "browserify index.js --o bundle.js",
-        "test": "mocha -r esm"
+        "test": "mocha -r esm",
+        "release": "semantic-release"
     },
     "devDependencies": {
+        "@semantic-release/changelog": "^7.0.0",
+        "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/git": "^11.0.1",
+        "@semantic-release/github": "^12.0.9",
+        "@semantic-release/npm": "^13.1.5",
+        "@semantic-release/release-notes-generator": "^14.1.1",
         "browserify": "^17.0.1",
+        "conventional-changelog-conventionalcommits": "^10.3.0",
         "esm": "^3.2.25",
         "mocha": "^10.8.2",
+        "semantic-release": "^25.0.9",
         "should": "^13.2.3"
     },
     "dependencies": {},


### PR DESCRIPTION
## Summary

Closes #101.

- Adds `.github/workflows/release.yml`, which runs [semantic-release](https://semantic-release.gitbook.io/semantic-release/) on every push to `main`. It runs the test suite, then analyzes commits since the last release (using the `conventionalcommits` preset) to determine the next version, publishes to npm, creates a GitHub release with generated notes, and commits an updated `CHANGELOG.md` back to `main`.
- Adds `.releaserc.json` configuring the `commit-analyzer` / `release-notes-generator` (conventionalcommits preset), `changelog`, `npm`, `github`, and `git` plugins.
- Adds `.github/workflows/pr-title.yml`, which enforces that pull request titles follow [Conventional Commits](https://www.conventionalcommits.org/) via `amannn/action-semantic-pull-request`. Since PRs are squash-merged, the PR title becomes the commit on `main` that semantic-release analyzes, so this is what actually drives correct version bumps.
- Adds the `semantic-release` toolchain (`semantic-release`, `@semantic-release/{changelog,commit-analyzer,git,github,npm,release-notes-generator}`, `conventional-changelog-conventionalcommits`) as devDependencies, and a `release` npm script.
- Documents the release process and commit/PR title conventions in the README.

## Setup required before this can publish

This PR cannot configure repository secrets itself — before the `release` workflow can successfully publish:

1. Create an npm [automation or publish access token](https://docs.npmjs.com/creating-and-viewing-access-tokens) for the `keyword-extractor` package.
2. Add it as a repository secret named `NPM_TOKEN` (Settings → Secrets and variables → Actions).

Until that's done, the release job will run tests successfully but fail at the publish step.

## Test plan

- [x] `npm install` resolves cleanly with the new devDependencies.
- [x] `npm test` — all 65 existing tests pass.
- [x] `npx semantic-release --dry-run --no-ci` on this branch: all plugins load successfully; semantic-release correctly refuses to run because the branch isn't `main` (confirms `.releaserc.json`'s `branches: ["main"]` restriction works as intended).
- [ ] After merge + `NPM_TOKEN` secret is added: verify the `release` workflow successfully publishes on the next release-worthy commit to `main`.
- [ ] Open a test PR with a non-conventional title to confirm the `pr-title` check fails as expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3SU2hGx3DJPH9u5u7f8e1)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates npm releases with `semantic-release` on pushes to `main` and enforces Conventional Commit PR titles so squash merges drive correct versioning. Uses plain version tags (`"${version}"`, no "v") to match existing tags and avoid an unintended fresh 1.0.0; runs on Node 22 with non-cancelling concurrency; authenticates to npm via Trusted Publishing (OIDC) with `NPM_TOKEN` as a fallback.

- Review notes
  - Release job: Node 22 → `npm ci` → `make test` → `npx semantic-release`; concurrency group `release` (non-cancelling); `id-token: write` enabled for npm Trusted Publishing.
  - `.releaserc.json`: `branches: ["main"]`, `tagFormat: "${version}"`; plugins `@semantic-release/{commit-analyzer,release-notes-generator,changelog,npm,github,git}` commit `CHANGELOG.md`, `package.json`, and `package-lock.json`.
  - PR title check via `amannn/action-semantic-pull-request@v5`; README fixes mapping so `perf` and `revert` trigger patch releases.

- Required actions
  - If npm Trusted Publishing is enabled for this package, no action is needed. Otherwise add an `NPM_TOKEN` repository secret for fallback publishing.
  - Continue squash-merging and use Conventional Commit PR titles; use `!` or a `BREAKING CHANGE:` footer for majors.

<sup>Written for commit bcffca821e5b0d18d169bc4a4971ab06032f12d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

