### PR TITLE
fix(release): stop pushing a version-bump commit to protected main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,19 +16,7 @@
                 "preset": "conventionalcommits"
             }
         ],
-        "@semantic-release/changelog",
         "@semantic-release/npm",
-        "@semantic-release/github",
-        [
-            "@semantic-release/git",
-            {
-                "assets": [
-                    "CHANGELOG.md",
-                    "package.json",
-                    "package-lock.json"
-                ],
-                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-            }
-        ]
+        "@semantic-release/github"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Type       | Description                                | Release
 `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore` | No user-facing change | None
 Any type with a `BREAKING CHANGE:` footer or a `!` after the type/scope (e.g. `feat!:`) | Breaking API change | Major
 
+Release notes for each version are published on the [GitHub Releases page](https://github.com/michaeldelorenzo/keyword-extractor/releases) —
+there's no `CHANGELOG.md` committed to the repo, since `main` is a protected branch and the release automation can't push commits to it.
+
 ## Credits
 
 The initial stopwords lists are taken from the following sources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,7 @@
             "name": "keyword-extractor",
             "version": "0.0.28",
             "devDependencies": {
-                "@semantic-release/changelog": "^7.0.0",
                 "@semantic-release/commit-analyzer": "^13.0.1",
-                "@semantic-release/git": "^11.0.1",
                 "@semantic-release/github": "^12.0.9",
                 "@semantic-release/npm": "^13.1.5",
                 "@semantic-release/release-notes-generator": "^14.1.1",
@@ -346,24 +344,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@semantic-release/changelog": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-7.0.0.tgz",
-            "integrity": "sha512-TNPyag5db24o7jWjre7UwKB4EcL8oJxbRhnDQ7hmZRAYqzreAc6PgdxQuU3pppp5xQinYtiumL0iG8SSKvnlzg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@semantic-release/error": "^4.0.0",
-                "aggregate-error": "^5.0.0",
-                "lodash-es": "^4.17.21"
-            },
-            "engines": {
-                "node": "^22.22.2 || >=24.15"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
-            }
-        },
         "node_modules/@semantic-release/commit-analyzer": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
@@ -395,29 +375,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/@semantic-release/git": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-11.0.1.tgz",
-            "integrity": "sha512-Zr8BUYCTZMc8V6wDKN2dpR7nJgewd9I6THL3ydLTnp3OEdTo1/4RBLNYaeRucYMsjMv+BXoCNfXA0NADj1kwhw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@semantic-release/error": "^4.0.0",
-                "aggregate-error": "^5.0.0",
-                "debug": "^4.0.0",
-                "dir-glob": "^3.0.0",
-                "execa": "^10.0.0",
-                "lodash-es": "^4.17.21",
-                "micromatch": "^4.0.0",
-                "p-reduce": "^3.0.0"
-            },
-            "engines": {
-                "node": "^22.22.2 || >=24.15"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
             }
         },
         "node_modules/@semantic-release/github": {
@@ -2114,46 +2071,6 @@
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "node_modules/execa": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
-            "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "figures": "^6.1.0",
-                "get-stream": "^9.0.1",
-                "human-signals": "^8.0.1",
-                "is-plain-obj": "^4.1.0",
-                "is-stream": "^4.0.1",
-                "npm-run-path": "^6.0.0",
-                "pretty-ms": "^9.3.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^4.0.0",
-                "which-command": "^0.1.0",
-                "yoctocolors": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=22"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/execa/node_modules/is-plain-obj": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/fast-safe-stringify": {
@@ -7853,22 +7770,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/which-command": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
-            "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "which-command": "cli.js"
-            },
-            "engines": {
-                "node": ">=22"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/which-command?sponsor=1"
-            }
-        },
         "node_modules/which-typed-array": {
             "version": "1.1.22",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -8255,17 +8156,6 @@
             "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
             "dev": true
         },
-        "@semantic-release/changelog": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-7.0.0.tgz",
-            "integrity": "sha512-TNPyag5db24o7jWjre7UwKB4EcL8oJxbRhnDQ7hmZRAYqzreAc6PgdxQuU3pppp5xQinYtiumL0iG8SSKvnlzg==",
-            "dev": true,
-            "requires": {
-                "@semantic-release/error": "^4.0.0",
-                "aggregate-error": "^5.0.0",
-                "lodash-es": "^4.17.21"
-            }
-        },
         "@semantic-release/commit-analyzer": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
@@ -8287,22 +8177,6 @@
             "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
             "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
             "dev": true
-        },
-        "@semantic-release/git": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-11.0.1.tgz",
-            "integrity": "sha512-Zr8BUYCTZMc8V6wDKN2dpR7nJgewd9I6THL3ydLTnp3OEdTo1/4RBLNYaeRucYMsjMv+BXoCNfXA0NADj1kwhw==",
-            "dev": true,
-            "requires": {
-                "@semantic-release/error": "^4.0.0",
-                "aggregate-error": "^5.0.0",
-                "debug": "^4.0.0",
-                "dir-glob": "^3.0.0",
-                "execa": "^10.0.0",
-                "lodash-es": "^4.17.21",
-                "micromatch": "^4.0.0",
-                "p-reduce": "^3.0.0"
-            }
         },
         "@semantic-release/github": {
             "version": "12.0.9",
@@ -9579,34 +9453,6 @@
             "requires": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "execa": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
-            "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
-            "dev": true,
-            "requires": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "figures": "^6.1.0",
-                "get-stream": "^9.0.1",
-                "human-signals": "^8.0.1",
-                "is-plain-obj": "^4.1.0",
-                "is-stream": "^4.0.1",
-                "npm-run-path": "^6.0.0",
-                "pretty-ms": "^9.3.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^4.0.0",
-                "which-command": "^0.1.0",
-                "yoctocolors": "^2.1.2"
-            },
-            "dependencies": {
-                "is-plain-obj": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-                    "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-                    "dev": true
-                }
             }
         },
         "fast-safe-stringify": {
@@ -13512,12 +13358,6 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
-        },
-        "which-command": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
-            "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
-            "dev": true
         },
         "which-typed-array": {
             "version": "1.1.22",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "homepage": "https://github.com/michaeldelorenzo/keyword-extractor",
     "repository": {
         "type": "git",
-        "url": "git://github.com/michaeldelorenzo/keyword-extractor.git"
+        "url": "git+https://github.com/michaeldelorenzo/keyword-extractor.git"
     },
     "bugs": {
         "url": "https://github.com/michaeldelorenzo/keyword-extractor/issues"
@@ -40,9 +40,7 @@
         "release": "semantic-release"
     },
     "devDependencies": {
-        "@semantic-release/changelog": "^7.0.0",
         "@semantic-release/commit-analyzer": "^13.0.1",
-        "@semantic-release/git": "^11.0.1",
         "@semantic-release/github": "^12.0.9",
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.1",


### PR DESCRIPTION
## Summary

The first real `release` workflow run (triggered by #102 merging) failed: [run 31714646000](https://github.com/michaeldelorenzo/keyword-extractor/actions/runs/31714646000/job/94496125204).

Everything worked correctly up to the last step — version `0.1.0` was computed correctly from the squashed `feat:` commit, `CHANGELOG.md` was generated, and `package.json`'s version was bumped locally — but `@semantic-release/git` then tried to push that commit straight to `main`:

```
git push --tags ... HEAD:main
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

`main`'s branch protection (require PR + status checks) rejects any direct push, including from the workflow's token. Since the whole semantic-release run aborts on any failed step, nothing published — no npm release, no GitHub release, no tag.

## Fix

Rather than loosening branch protection on `main`, this drops the `@semantic-release/git` and `@semantic-release/changelog` plugins from `.releaserc.json`. Neither is required for the actual release to work:

- Semantic-release's own tag push (`git push --tags`, no branch ref) isn't subject to "require pull request" protection — only `@semantic-release/git`'s `HEAD:main` push was.
- `@semantic-release/github` already includes the full generated release notes in the GitHub Release body, independent of whether a `CHANGELOG.md` file exists in the repo.

Confirmed via `semantic-release`'s own source (`node_modules/semantic-release/lib/git.js`) that core's `push()` only ever does `git push --tags -- repositoryUrl` — `@semantic-release/git` was the only plugin pushing a commit to the branch.

Also fixed `package.json`'s `repository.url`, which was still the deprecated, unauthenticated `git://` protocol (GitHub disabled anonymous `git://` access years ago). This is harmless for the actual workflow, which authenticates via `GITHUB_TOKEN`/npm OIDC directly rather than this field, but it caused confusing failures while reproducing this locally, so cleaned it up to `git+https://`.

## Trade-off

`package.json`'s committed `version` field and a repo `CHANGELOG.md` are no longer kept in sync automatically. Neither was ever load-bearing for npm publishing — semantic-release derives the next version from git tags, not `package.json`. Release notes remain fully available on the [GitHub Releases page](https://github.com/michaeldelorenzo/keyword-extractor/releases). README updated to reflect this.

## Test plan

- [x] `npm test` — all 65 tests pass.
- [x] `npx semantic-release --dry-run --no-ci` — all plugins (`commit-analyzer`, `release-notes-generator`, `npm`, `github`) load cleanly with no config errors.
- [ ] After merge: verify the next release-worthy push to `main` successfully publishes to npm and creates a GitHub release/tag without hitting the protected-branch error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3SU2hGx3DJPH9u5u7f8e1)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop release from pushing version-bump commits to protected `main` by removing `@semantic-release/git` and `@semantic-release/changelog`. Previously the workflow failed when it tried to push to `main`; now it only pushes tags and publishes to npm/GitHub releases. Side effect: no committed `CHANGELOG.md` and `package.json`’s version will not auto-update.

- Review notes
  - Drop `@semantic-release/git` and `@semantic-release/changelog` from `.releaserc.json`; keep `@semantic-release/npm` and `@semantic-release/github`.
  - Update `README.md` to point to GitHub Releases; remove expectation of a `CHANGELOG.md`.
  - Change `package.json` repository URL to `git+https://`.

- Rollout
  - No migration required. Expect future releases to publish without branch pushes; do not expect a committed changelog or version bumps in `package.json`.

<sup>Written for commit 0b148263e6e88ac722c47c5fe044fb4e0f6e4d44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

