### PR TITLE
docs: document TypeScript usage and remove dead type exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ keyword_extractor.extract(sentence,{
 */
 ```
 
+### TypeScript
+
+This package ships its own type declarations, so no `@types` package is needed. Usage is the same, but with
+`import`/typed options:
+
+```typescript
+import keyword_extractor from "keyword-extractor";
+
+const extraction_result: string[] = keyword_extractor.extract(sentence, {
+    language: "english",
+    remove_digits: true,
+    return_changed_case: true,
+    remove_duplicates: false
+});
+```
+
 ### Options Parameters
 
 The second argument of the _extract_ method is an Object of configuration/processing settings for the extraction.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ This package ships its own type declarations, so no `@types` package is needed. 
 ```typescript
 import keyword_extractor from "keyword-extractor";
 
+const sentence = "President Obama woke up Monday facing a Congressional defeat.";
+
 const extraction_result: string[] = keyword_extractor.extract(sentence, {
     language: "english",
     remove_digits: true,

--- a/types/lib/keyword_extractor.d.ts
+++ b/types/lib/keyword_extractor.d.ts
@@ -10,19 +10,5 @@ type ExtractionOptions = {
   stopwords?: string[];
 } & GetStopwordsOptions;
 
-/**
- * Extracts keywords from the given string.
- * @param {string} str The string to extract keywords from.
- * @param {ExtractionOptions | undefined} options Options for the keyword extraction tool.
- */
-export declare function _extract(str: string, options?: ExtractionOptions): string[]
-
-
-/**
- * Returns the array of stopwords.
- * @param {GetStopwordsOptions | undefined} options
- */
-export declare function _getStopwords(options?: GetStopwordsOptions): string[];
-
 /** Provides the list of supported ISO 639-1 language codes */
 export declare const supported_language_codes: string[];


### PR DESCRIPTION
## Summary

TypeScript support (#44) was already implemented in #47 and refined in #82 — the package ships working `.d.ts` files and `tsc --strict` type-checks cleanly against them. This PR is a small follow-up cleanup, not new functionality:

- Removes the unused `_extract`/`_getStopwords` declarations from `types/lib/keyword_extractor.d.ts`. These were dead: `types/index.d.ts` declares its own typed `extract`/`getStopwords` signatures directly and never imports these underscore-prefixed ones.
- Adds a short "TypeScript" section to the README with an example, so the existing type support is discoverable (previously undocumented).

## Test plan

- [x] `npm test` — all 65 existing tests pass
- [x] Manually type-checked a sample `.ts` file (`import`, `extract`, `getStopwords`, `supported_language_codes`) against the shipped types with `tsc --noEmit --strict` before and after the cleanup — compiles clean both times


---
_Generated by [Claude Code](https://claude.ai/code/session_015yCmnkBVQdGAmxJ8K95Hi8)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents TypeScript usage for `keyword-extractor` with a complete example (now declares `sentence`) and removes unused `_extract`/`_getStopwords` type declarations. Improves discoverability of existing TypeScript support without changing behavior.

- Public types are unchanged: `extract`, `getStopwords`, and `supported_language_codes` remain via `types/index.d.ts`.
- Cleanup is limited to `types/lib/keyword_extractor.d.ts`; only the underscore-prefixed declarations were removed.
- No runtime or API changes; strict type-checking still passes. No migration required.

<sup>Written for commit 2d8718b3aa519d84e8797f9afc530e637f9fefc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

