### PR TITLE
feat(#88): add ESM support with named exports and export map

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ keyword_extractor.extract(sentence,{
 */
 ```
 
+The module can also be imported with ES module syntax, e.g. in Next.js apps or other ESM-based projects:
+
+```javascript
+import keyword_extractor from "keyword-extractor";
+// or, using named imports:
+// import { extract, getStopwords, supported_language_codes } from "keyword-extractor";
+
+const extraction_result = keyword_extractor.extract(sentence, {
+    language: "english",
+    remove_digits: true,
+    return_changed_case: true,
+    remove_duplicates: false
+});
+```
+
 ### Options Parameters
 
 The second argument of the _extract_ method is an Object of configuration/processing settings for the extraction.

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,4 @@
+import keyword_extractor from "./index.js";
+
+export const { extract, getStopwords, supported_language_codes } = keyword_extractor;
+export default keyword_extractor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "should": "^13.2.3"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">= 14"
             }
         },
         "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,14 @@
     "bugs": {
         "url": "https://github.com/michaeldelorenzo/keyword-extractor/issues"
     },
-    "main": "./index",
+    "main": "./index.js",
+    "exports": {
+        ".": {
+            "types": "./types/index.d.ts",
+            "import": "./index.mjs",
+            "require": "./index.js"
+        }
+    },
     "scripts": {
         "start": "browserify index.js --o bundle.js",
         "test": "mocha -r esm",
@@ -57,6 +64,6 @@
         "serialize-javascript": "^7.1.0"
     },
     "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 14"
     }
 }

--- a/test/test.esm-exports.mjs
+++ b/test/test.esm-exports.mjs
@@ -1,0 +1,31 @@
+import { createRequire } from "node:module";
+import assert from "node:assert/strict";
+import * as esm_extractor from "../index.mjs";
+
+const require = createRequire(import.meta.url);
+const cjs_extractor = require("../index.js");
+
+describe("ESM/CJS export parity", function () {
+  it("exposes the same named exports as the CommonJS module", function () {
+    const cjs_keys = Object.keys(cjs_extractor).sort();
+    const esm_keys = Object.keys(esm_extractor)
+      .filter((key) => key !== "default")
+      .sort();
+
+    assert.deepStrictEqual(
+      esm_keys,
+      cjs_keys,
+      "index.mjs must re-export exactly the same named exports as index.js"
+    );
+  });
+
+  it("re-exports the exact same values as the CommonJS module", function () {
+    for (const key of Object.keys(cjs_extractor)) {
+      assert.strictEqual(esm_extractor[key], cjs_extractor[key]);
+    }
+  });
+
+  it("exposes a default export equal to the CommonJS module.exports", function () {
+    assert.strictEqual(esm_extractor.default, cjs_extractor);
+  });
+});

--- a/test/test.esm-exports.mjs
+++ b/test/test.esm-exports.mjs
@@ -1,5 +1,5 @@
-import { createRequire } from "node:module";
-import assert from "node:assert/strict";
+import { createRequire } from "module";
+import { strict as assert } from "assert";
 import * as esm_extractor from "../index.mjs";
 
 const require = createRequire(import.meta.url);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,4 +9,8 @@ declare const keyword_extractor: {
   supported_language_codes: string[];
 };
 
+export declare const extract: (str: string, options?: ExtractionOptions) => string[];
+export declare const getStopwords: (options?: GetStopwordsOptions) => string[];
+export declare const supported_language_codes: string[];
+
 export default keyword_extractor;


### PR DESCRIPTION
## Summary
This PR adds full ES module (ESM) support to the keyword-extractor package, allowing it to be used in modern ESM-based projects like Next.js while maintaining backward compatibility with CommonJS.

## Key Changes
- **Added `index.mjs`**: New ESM entry point that re-exports the CommonJS module with both named exports (`extract`, `getStopwords`, `supported_language_codes`) and a default export
- **Updated `package.json`**: 
  - Added `exports` field with conditional exports for ESM (`import`) and CommonJS (`require`) entry points
  - Included TypeScript types reference in the exports map
  - Changed `main` field from `"./index"` to `"./index.js"` for clarity
  - Updated Node.js engine requirement from `>= 0.10.0` to `>= 14` (required for ESM support)
- **Added test suite**: New `test/test.esm-exports.mjs` file that verifies:
  - ESM and CJS modules export the same named exports
  - Exported values are identical between both module systems
  - Default export equals the CommonJS module.exports
- **Updated README.md**: Added documentation showing how to import the module using ESM syntax

## Implementation Details
The ESM module is implemented as a thin wrapper around the existing CommonJS module, ensuring that both module systems reference the same underlying code and maintain perfect parity. This approach minimizes duplication while providing a seamless experience for both CommonJS and ESM consumers.

https://claude.ai/code/session_016W4LMNbwctnViy7zNMVp1A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ESM support and an `exports` map to `keyword-extractor`, enabling `import` in ESM/Next.js while preserving `require`. Also adds named export type declarations so TypeScript NodeNext projects can use named imports without errors.

- Introduces `index.mjs`, a thin wrapper around `index.js` with named exports (`extract`, `getStopwords`, `supported_language_codes`) and a default export.
- Updates `package.json` with conditional `exports` (`import` → `index.mjs`, `require` → `index.js`) plus `types`, and keeps `main` at `./index.js`; raises engines to Node >=14.
- Adds a parity test to keep ESM and CJS exports in sync under Node 14.
- Extends `types/index.d.ts` to declare the named exports so TS named imports type-check.
- Documents ESM usage in the README.

**Migration**
- CommonJS: no change; `require("keyword-extractor")` still works.
- ESM: `import keyword_extractor, { extract, getStopwords, supported_language_codes } from "keyword-extractor"`.
- Node <14: upgrade Node.

<sup>Written for commit 74d80eb840d7c19e62d4546d8fcae14df5095b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

