### PR TITLE
fix(#43): correct chain-adjacency check for return_chained_words

### DIFF
--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -51,6 +51,7 @@ function extract(
     const words = text.split(/\s/);
     const unchanged_words = [];
     const low_words = [];
+    const word_positions = [];
     //  change the case of all the words
     for (let x = 0; x < words.length; x++) {
       let w = words[x].match(/https?:\/\/.*[\r\n]*/g)
@@ -69,17 +70,25 @@ function extract(
       if (w.length > 0) {
         low_words.push(w.toLowerCase());
         unchanged_words.push(w);
+        //  track the word's position in the original text, since words
+        //  dropped above (digits, stray punctuation) leave a gap that
+        //  should still break a chain of "originally together" words
+        word_positions.push(x);
       }
     }
     let results = [];
     const _stopwords =
       options.stopwords || getStopwords({ language: _language });
-    let _last_result_word_index = 0;
+    let _last_result_word_index = -1;
     let _start_result_word_index = 0;
     let _unbroken_word_chain = false;
     for (let y = 0; y < low_words.length; y++) {
       if (_stopwords.indexOf(low_words[y]) < 0) {
-        if (_last_result_word_index !== y - 1) {
+        const _is_adjacent =
+          _last_result_word_index >= 0 &&
+          word_positions[y] === word_positions[_last_result_word_index] + 1;
+
+        if (!_is_adjacent) {
           _start_result_word_index = y;
           _unbroken_word_chain = false;
         } else {
@@ -96,13 +105,13 @@ function extract(
           _unbroken_word_chain &&
           !return_chained_words &&
           return_max_ngrams > y - _start_result_word_index &&
-          _last_result_word_index === y - 1
+          _is_adjacent
         ) {
           const change_pos = results.length - 1 < 0 ? 0 : results.length - 1;
           results[change_pos] = results[change_pos]
             ? results[change_pos] + " " + result_word
             : result_word;
-        } else if (return_chained_words && _last_result_word_index === y - 1) {
+        } else if (return_chained_words && _is_adjacent) {
           const change_pos = results.length - 1 < 0 ? 0 : results.length - 1;
           results[change_pos] = results[change_pos]
             ? results[change_pos] + " " + result_word

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -48,7 +48,10 @@ function extract(
   if (!text) {
     return [];
   } else {
-    const words = text.split(/\s/);
+    //  split on runs of whitespace, not each whitespace character, so that
+    //  repeated spaces/tabs/newlines between words don't produce empty
+    //  placeholders that would be mistaken for a real gap below
+    const words = text.split(/\s+/);
     const unchanged_words = [];
     const low_words = [];
     const word_positions = [];

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -15,6 +15,31 @@ describe("extractor", function(){
             extractor.extract("an associated behind",{language:"en"}).should.be.empty;
         });
 
+        it("should not chain 'keywords' separated by digits that get removed (regression #43)", function() {
+          var extraction_result = extractor.extract("Linux 123 Foundation", {
+              language:"en",
+              remove_digits:true,
+              return_chained_words:true
+          });
+          extraction_result.should.eql(["Linux","Foundation"]);
+        });
+
+        it("should not chain 'keywords' separated by a stray symbol that gets removed (regression #43)", function() {
+          var extraction_result = extractor.extract("Linux & Foundation", {
+              language:"en",
+              return_chained_words:true
+          });
+          extraction_result.should.eql(["Linux","Foundation"]);
+        });
+
+        it("should still chain 'keywords' that are truly adjacent in the original text", function() {
+          var extraction_result = extractor.extract("Linux Foundation", {
+              language:"en",
+              return_chained_words:true
+          });
+          extraction_result.should.eql(["Linux Foundation"]);
+        });
+
         it("should return an array of 'keywords' for an English string", function(){
             var extraction_result = extractor.extract("President Obama woke up Monday facing a Congressional defeat that many in both parties believed could hobble his presidency.",{
                 language:"en",

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -40,6 +40,14 @@ describe("extractor", function(){
           extraction_result.should.eql(["Linux Foundation"]);
         });
 
+        it("should still chain 'keywords' separated by repeated whitespace", function() {
+          var extraction_result = extractor.extract("Linux   \t\n  Foundation", {
+              language:"en",
+              return_chained_words:true
+          });
+          extraction_result.should.eql(["Linux Foundation"]);
+        });
+
         it("should return an array of 'keywords' for an English string", function(){
             var extraction_result = extractor.extract("President Obama woke up Monday facing a Congressional defeat that many in both parties believed could hobble his presidency.",{
                 language:"en",


### PR DESCRIPTION
## Summary
Fixed a bug where keywords separated by removed characters (digits or punctuation) were incorrectly chained together when `return_chained_words` is enabled.

## Key Changes
- Added `word_positions` array to track the original position of each keyword in the input text, accounting for words that were filtered out during preprocessing
- Changed adjacency detection from comparing filtered word indices (`y - 1`) to comparing original text positions (`word_positions[y] === word_positions[_last_result_word_index] + 1`)
- Updated initialization of `_last_result_word_index` from `0` to `-1` to properly handle the first keyword
- Applied the new adjacency check consistently across all chaining logic

## Implementation Details
The fix ensures that keywords are only chained together if they were truly adjacent in the original text. Previously, the code compared indices in the filtered word array, which caused words separated by removed digits or punctuation to appear adjacent. Now it tracks original positions, so "Linux 123 Foundation" with `remove_digits:true` correctly returns `["Linux", "Foundation"]` instead of `["Linux Foundation"]`, while "Linux Foundation" still correctly returns `["Linux Foundation"]`.

## Tests Added
- Regression test for keywords separated by digits that get removed
- Regression test for keywords separated by stray symbols that get removed  
- Test confirming that truly adjacent keywords are still properly chained

https://claude.ai/code/session_01RuLXiMWuWxr6o7fg6Km5vQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyword chaining to respect original adjacency and not be broken by repeated whitespace. Previously, return_chained_words merged words separated by removed digits/symbols and could fail to chain across runs of spaces/tabs/newlines; now only truly adjacent words chain and repeated whitespace still chains.

- Track original positions for kept words and derive adjacency via `_is_adjacent`; initialize `_last_result_word_index` to -1 and apply the check consistently, including with `return_max_ngrams`.
- Split input on runs of whitespace (`\s+`) to avoid empty tokens that created false gaps.
- Tests cover digits, stray symbols, and repeated whitespace; confirm chaining for truly adjacent words.
- No API changes. Outputs may split phrases that were previously merged when digits/symbols were removed.

<sup>Written for commit f1025bc213d7415a28429a55d543da9c78f4a449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

