### PR TITLE
ci: upgrade actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow dependencies to their latest major versions to ensure compatibility and access to the latest features and security updates.

## Key Changes
- Upgraded `actions/checkout` from v4 to v5
- Upgraded `actions/setup-node` from v4 to v5

## Details
These version bumps ensure the release workflow uses the latest stable versions of the official GitHub Actions, which may include performance improvements, bug fixes, and enhanced compatibility with current Node.js and GitHub infrastructure.

https://claude.ai/code/session_01Fs9tPSZv2RzpsRPjS3aDhy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the release workflow to v5 of `actions/checkout` and `actions/setup-node` to clear the "Node.js 20 is deprecated" warning. v4 ran on a Node 20 action runtime; v5 runs on Node 24. The workflow still installs Node 22 for the project, and behavior is otherwise unchanged.

- Only version pins changed in `.github/workflows/release.yml`.
- No migrations required; verify any scripts that depend on the action runtime are compatible with Node 24.

<sup>Written for commit 46a95e73535341f0b3dd78c2eebda34bcc7af420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

