### PR TITLE
feat(#69): add stopwords_regex option for pattern-based word removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ remove_duplicates | Removes the duplicate keywords | _true_ , _false_ (defaults 
 return_max_ngrams | Returns keywords that are ngrams with size 0-_integer_ | _integer_ , _false_ (defaults to _false_ )
 stopwords_regex | Removes any word matching one of the given regular expressions, in addition to the language's stopwords list. Useful for filtering out patterns that aren't in a fixed word list, such as units (`10lbs`, `10Kg`), times (`6pm`), or ranges (`1-100`) | Array of `RegExp` (defaults to _[]_ )
 
+Each pattern is tested against both the lowercased and original-case forms of a word, so patterns work
+whether or not they include the `i` flag.
+
 #### Removing words with `stopwords_regex`
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ return_changed_case | The case of the extracted keywords. Setting the value to _
 return_chained_words | Instead of returning each word separately, join the words that were originally together. Setting the value to _true_ will join the words, if _false_ the results will be splitted on each array element. | _true_ or _false_
 remove_duplicates | Removes the duplicate keywords | _true_ , _false_ (defaults to _false_ )
 return_max_ngrams | Returns keywords that are ngrams with size 0-_integer_ | _integer_ , _false_ (defaults to _false_ )
+stopwords_regex | Removes any word matching one of the given regular expressions, in addition to the language's stopwords list. Useful for filtering out patterns that aren't in a fixed word list, such as units (`10lbs`, `10Kg`), times (`6pm`), or ranges (`1-100`) | Array of `RegExp` (defaults to _[]_ )
+
+#### Removing words with `stopwords_regex`
+
+```javascript
+const extraction_result = keyword_extractor.extract("He weighed 10lbs at birth and grew to 10Kg, waking at 6pm daily.", {
+    language: "english",
+    stopwords_regex: [/^\d+[a-z]+$/i]
+});
+
+//  extraction_result is ["weighed", "birth", "grew", "waking", "daily"]
+```
 
 
 ## Releases

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -82,19 +82,26 @@ function extract(
     let results = [];
     const _stopwords =
       options.stopwords || getStopwords({ language: _language });
-    const _stopwords_regex = options.stopwords_regex || [];
+    //  strip global/sticky flags into fresh RegExp instances so testing
+    //  many words neither mutates the caller's regex objects nor carries
+    //  lastIndex state (which would skip alternating matches) between words
+    const _stopwords_regex = (options.stopwords_regex || []).map(
+      (regex) => new RegExp(regex.source, regex.flags.replace(/[gy]/g, ""))
+    );
     let _last_result_word_index = -1;
     let _start_result_word_index = 0;
     let _unbroken_word_chain = false;
     for (let y = 0; y < low_words.length; y++) {
       const _is_stopword =
         _stopwords.indexOf(low_words[y]) >= 0 ||
-        _stopwords_regex.some((regex) => {
-          //  reset lastIndex so a caller-supplied global/sticky regex
-          //  can't carry state between words and skip alternating matches
-          regex.lastIndex = 0;
-          return regex.test(low_words[y]);
-        });
+        //  test both the lowercased and original-case forms so a
+        //  case-sensitive pattern isn't limited to matching lowercase text
+        _stopwords_regex.some(
+          (regex) =>
+            regex.test(low_words[y]) ||
+            (low_words[y] !== unchanged_words[y] &&
+              regex.test(unchanged_words[y]))
+        );
       if (!_is_stopword) {
         const _is_adjacent =
           _last_result_word_index >= 0 &&

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -43,6 +43,18 @@ function extract(
 
   _language = sanitize_language(_language);
 
+  //  clone into fresh RegExp instances (keeping the caller's original
+  //  flags, including global/sticky) so testing many words can't mutate
+  //  the caller's own regex objects. Validated here, alongside the
+  //  language, so a malformed option always fails loudly rather than
+  //  only on non-empty input.
+  const _stopwords_regex = (options.stopwords_regex || []).map((regex) => {
+    if (!(regex instanceof RegExp)) {
+      throw new Error("stopwords_regex must be an array of RegExp objects");
+    }
+    return new RegExp(regex.source, regex.flags);
+  });
+
   //  strip any HTML and trim whitespace
   const text = str.replace(/(<([^>]+)>)/gi, "").trim();
   if (!text) {
@@ -82,12 +94,14 @@ function extract(
     let results = [];
     const _stopwords =
       options.stopwords || getStopwords({ language: _language });
-    //  strip global/sticky flags into fresh RegExp instances so testing
-    //  many words neither mutates the caller's regex objects nor carries
-    //  lastIndex state (which would skip alternating matches) between words
-    const _stopwords_regex = (options.stopwords_regex || []).map(
-      (regex) => new RegExp(regex.source, regex.flags.replace(/[gy]/g, ""))
-    );
+    //  reset lastIndex before every test so a global/sticky pattern's
+    //  match position never leaks between words, or between the
+    //  lowercased/original-case tests of the same word
+    const matches_stopword_regex = (word) =>
+      _stopwords_regex.some((regex) => {
+        regex.lastIndex = 0;
+        return regex.test(word);
+      });
     let _last_result_word_index = -1;
     let _start_result_word_index = 0;
     let _unbroken_word_chain = false;
@@ -96,12 +110,9 @@ function extract(
         _stopwords.indexOf(low_words[y]) >= 0 ||
         //  test both the lowercased and original-case forms so a
         //  case-sensitive pattern isn't limited to matching lowercase text
-        _stopwords_regex.some(
-          (regex) =>
-            regex.test(low_words[y]) ||
-            (low_words[y] !== unchanged_words[y] &&
-              regex.test(unchanged_words[y]))
-        );
+        matches_stopword_regex(low_words[y]) ||
+        (low_words[y] !== unchanged_words[y] &&
+          matches_stopword_regex(unchanged_words[y]));
       if (!_is_stopword) {
         const _is_adjacent =
           _last_result_word_index >= 0 &&

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -82,11 +82,20 @@ function extract(
     let results = [];
     const _stopwords =
       options.stopwords || getStopwords({ language: _language });
+    const _stopwords_regex = options.stopwords_regex || [];
     let _last_result_word_index = -1;
     let _start_result_word_index = 0;
     let _unbroken_word_chain = false;
     for (let y = 0; y < low_words.length; y++) {
-      if (_stopwords.indexOf(low_words[y]) < 0) {
+      const _is_stopword =
+        _stopwords.indexOf(low_words[y]) >= 0 ||
+        _stopwords_regex.some((regex) => {
+          //  reset lastIndex so a caller-supplied global/sticky regex
+          //  can't carry state between words and skip alternating matches
+          regex.lastIndex = 0;
+          return regex.test(low_words[y]);
+        });
+      if (!_is_stopword) {
         const _is_adjacent =
           _last_result_word_index >= 0 &&
           word_positions[y] === word_positions[_last_result_word_index] + 1;

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -30,6 +30,21 @@ function extract(
     return_changed_case: true,
   }
 ) {
+  //  clone into fresh RegExp instances (keeping the caller's original
+  //  flags, including global/sticky) so testing many words can't mutate
+  //  the caller's own regex objects. Validated before the `if (!str)`
+  //  early return below, so a malformed entry fails loudly even for an
+  //  empty/falsy str. The `options &&` guard only protects this early
+  //  access — it doesn't make a null/non-object `options` valid for a
+  //  non-empty str, which still fails the same way it always has,
+  //  further down where the other options fields are read.
+  const _stopwords_regex = ((options && options.stopwords_regex) || []).map((regex) => {
+    if (!(regex instanceof RegExp)) {
+      throw new Error("stopwords_regex must be an array of RegExp objects");
+    }
+    return new RegExp(regex.source, regex.flags);
+  });
+
   if (!str) {
     return [];
   }
@@ -42,18 +57,6 @@ function extract(
   const return_max_ngrams = options.return_max_ngrams;
 
   _language = sanitize_language(_language);
-
-  //  clone into fresh RegExp instances (keeping the caller's original
-  //  flags, including global/sticky) so testing many words can't mutate
-  //  the caller's own regex objects. Validated here, alongside the
-  //  language, so a malformed option always fails loudly rather than
-  //  only on non-empty input.
-  const _stopwords_regex = (options.stopwords_regex || []).map((regex) => {
-    if (!(regex instanceof RegExp)) {
-      throw new Error("stopwords_regex must be an array of RegExp objects");
-    }
-    return new RegExp(regex.source, regex.flags);
-  });
 
   //  strip any HTML and trim whitespace
   const text = str.replace(/(<([^>]+)>)/gi, "").trim();

--- a/lib/keyword_extractor.js
+++ b/lib/keyword_extractor.js
@@ -38,7 +38,14 @@ function extract(
   //  access — it doesn't make a null/non-object `options` valid for a
   //  non-empty str, which still fails the same way it always has,
   //  further down where the other options fields are read.
-  const _stopwords_regex = ((options && options.stopwords_regex) || []).map((regex) => {
+  const _stopwords_regex_option = options ? options.stopwords_regex : undefined;
+  //  any falsy value (undefined, null, false, 0, "") falls back to no
+  //  regexes below, same as the old `options.stopwords_regex || []`
+  //  fallback; only a truthy non-array is a genuine type mistake
+  if (_stopwords_regex_option && !Array.isArray(_stopwords_regex_option)) {
+    throw new Error("stopwords_regex must be an array of RegExp objects");
+  }
+  const _stopwords_regex = (_stopwords_regex_option || []).map((regex) => {
     if (!(regex instanceof RegExp)) {
       throw new Error("stopwords_regex must be an array of RegExp objects");
     }

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -321,6 +321,78 @@ describe("extractor", function(){
             extractor.getStopwords({language:"english"}).should.not.be.empty;
         });
 
+        describe("stopwords_regex option (#69)", function(){
+            it("should remove words matching a unit-suffixed number pattern (e.g. '10lbs', '10Kg', '6pm')", function(){
+                var extraction_result = extractor.extract("He weighed 10lbs at birth and grew to 10Kg, waking at 6pm daily.", {
+                    language: "en",
+                    remove_digits: false,
+                    stopwords_regex: [/^\d+[a-z]+$/i]
+                });
+                extraction_result.should.eql(["weighed","birth","grew","waking","daily"]);
+            });
+
+            it("should remove words matching a numeric-range pattern (e.g. '1-100')", function(){
+                var extraction_result = extractor.extract("Choose a number between 1-100 to win.", {
+                    language: "en",
+                    return_changed_case: true,
+                    stopwords_regex: [/^\d+-\d+$/]
+                });
+                extraction_result.should.eql(["choose","number","win"]);
+            });
+
+            it("should support multiple regexes at once", function(){
+                var extraction_result = extractor.extract("He weighed 10lbs and picked a number between 1-100.", {
+                    language: "en",
+                    return_changed_case: true,
+                    stopwords_regex: [/^\d+[a-z]+$/i, /^\d+-\d+$/]
+                });
+                extraction_result.should.eql(["weighed","picked","number"]);
+            });
+
+            it("should not remove anything when stopwords_regex is omitted (no regression)", function(){
+                var extraction_result = extractor.extract("He weighed 10lbs at birth.", {
+                    language: "en",
+                    remove_digits: false
+                });
+                extraction_result.should.eql(["weighed","10lbs","birth"]);
+            });
+
+            it("should not remove anything when stopwords_regex matches nothing", function(){
+                var extraction_result = extractor.extract("President Obama woke up Monday.", {
+                    language: "en",
+                    return_changed_case: true,
+                    stopwords_regex: [/^\d+[a-z]+$/i]
+                });
+                extraction_result.should.eql(["president","obama","woke","monday"]);
+            });
+
+            it("should still chain adjacent 'keywords' separated by a regex-removed word (regression #43 style)", function(){
+                var extraction_result = extractor.extract("Linux 10lbs Foundation", {
+                    language: "en",
+                    return_chained_words: true,
+                    stopwords_regex: [/^\d+[a-z]+$/i]
+                });
+                extraction_result.should.eql(["Linux","Foundation"]);
+            });
+
+            it("should compose correctly with remove_duplicates", function(){
+                var extraction_result = extractor.extract("10lbs 10lbs weighed weighed", {
+                    language: "en",
+                    stopwords_regex: [/^\d+[a-z]+$/i],
+                    remove_duplicates: true
+                });
+                extraction_result.should.eql(["weighed"]);
+            });
+
+            it("should not carry lastIndex state between words for a global regex (stateful regex safety)", function(){
+                var extraction_result = extractor.extract("10lbs 10kg weighed", {
+                    language: "en",
+                    stopwords_regex: [/^\d+[a-z]+$/gi]
+                });
+                extraction_result.should.eql(["weighed"]);
+            });
+        });
+
         it("should return an array of 'keywords' for a Turkish string", function(){
             var extraction_result = extractor.extract("Türk Dil dilli dil dilin dillerin Kurumunun kurumunun 1945’ten beri yayımlanan Türkçe Sözlük’ünün 2011 yılında yapılan 11. baskısının gözden geçirilip güncellenmiş olarak genel ağdan sunulan sürümüdür. Türkçe Sözlük dilimizde yaşanan gelişmelere bağlı olarak sürekli güncellenmektedir.",{
                 language:"tr",

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -445,6 +445,25 @@ describe("extractor", function(){
                 }).should.throw("stopwords_regex must be an array of RegExp objects");
             });
 
+            it("should throw a clear error when stopwords_regex is a single RegExp instead of an array", function(){
+                (function(){
+                    extractor.extract("10lbs weighed", {
+                        language: "en",
+                        stopwords_regex: /^\d+[a-z]+$/i
+                    });
+                }).should.throw("stopwords_regex must be an array of RegExp objects");
+            });
+
+            it("should treat any falsy stopwords_regex value the same as omitting it", function(){
+                [null, false, 0, ""].forEach(function(falsy_value){
+                    var extraction_result = extractor.extract("10lbs weighed", {
+                        language: "en",
+                        stopwords_regex: falsy_value
+                    });
+                    extraction_result.should.eql(["10lbs","weighed"]);
+                });
+            });
+
             it("should throw the same error for a non-RegExp entry even when the input trims to empty text", function(){
                 (function(){
                     extractor.extract("   ", {

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -391,6 +391,25 @@ describe("extractor", function(){
                 });
                 extraction_result.should.eql(["weighed"]);
             });
+
+            it("should not mutate a caller-supplied global/sticky regex's lastIndex", function(){
+                var shared_regex = /^\d+[a-z]+$/gi;
+                extractor.extract("10lbs 10kg weighed", {
+                    language: "en",
+                    stopwords_regex: [shared_regex]
+                });
+                shared_regex.lastIndex.should.eql(0);
+            });
+
+            it("should match a case-sensitive pattern against the original-case word, not just the lowercased form", function(){
+                var extraction_result = extractor.extract("The ABC123 unit failed but xyz456 passed.", {
+                    language: "en",
+                    stopwords_regex: [/^[A-Z]+\d+$/]
+                });
+                //  "ABC123" is removed (matches the original-case pattern), "xyz456" is kept
+                //  ("the"/"but" are removed as ordinary English stopwords, unrelated to the regex)
+                extraction_result.should.eql(["unit","failed","xyz456","passed"]);
+            });
         });
 
         it("should return an array of 'keywords' for a Turkish string", function(){

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -10,6 +10,10 @@ describe("extractor", function(){
         extractor.extract("   ").should.be.empty;
     });
 
+    it("should return an empty array for an empty string even when options is explicitly null (does not reach stopwords_regex validation)", function(){
+        extractor.extract("", null).should.be.empty;
+    });
+
     describe("ISO 639-1 language code format", function(){
         it("should return an emtpy array for a string that only contains stopwords", function(){
             extractor.extract("an associated behind",{language:"en"}).should.be.empty;
@@ -444,6 +448,15 @@ describe("extractor", function(){
             it("should throw the same error for a non-RegExp entry even when the input trims to empty text", function(){
                 (function(){
                     extractor.extract("   ", {
+                        language: "en",
+                        stopwords_regex: ["not-a-regex"]
+                    });
+                }).should.throw("stopwords_regex must be an array of RegExp objects");
+            });
+
+            it("should throw the same error for a non-RegExp entry even when str is empty", function(){
+                (function(){
+                    extractor.extract("", {
                         language: "en",
                         stopwords_regex: ["not-a-regex"]
                     });

--- a/test/test.keyword-extractor.js
+++ b/test/test.keyword-extractor.js
@@ -392,13 +392,34 @@ describe("extractor", function(){
                 extraction_result.should.eql(["weighed"]);
             });
 
-            it("should not mutate a caller-supplied global/sticky regex's lastIndex", function(){
+            it("should not mutate a caller-supplied global regex's lastIndex", function(){
                 var shared_regex = /^\d+[a-z]+$/gi;
+                shared_regex.lastIndex = 3;
                 extractor.extract("10lbs 10kg weighed", {
                     language: "en",
                     stopwords_regex: [shared_regex]
                 });
-                shared_regex.lastIndex.should.eql(0);
+                shared_regex.lastIndex.should.eql(3);
+            });
+
+            it("should not mutate a caller-supplied sticky regex's lastIndex", function(){
+                var shared_regex = /^\d+[a-z]+$/y;
+                shared_regex.lastIndex = 3;
+                extractor.extract("10lbs 10kg weighed", {
+                    language: "en",
+                    stopwords_regex: [shared_regex]
+                });
+                shared_regex.lastIndex.should.eql(3);
+            });
+
+            it("should preserve sticky-flag anchoring instead of turning it into an unanchored search", function(){
+                var extraction_result = extractor.extract("foobar bar", {
+                    language: "en",
+                    stopwords_regex: [/bar/y]
+                });
+                //  sticky /bar/y only matches when "bar" starts at position 0,
+                //  so "foobar" must be kept while the standalone "bar" is removed
+                extraction_result.should.eql(["foobar"]);
             });
 
             it("should match a case-sensitive pattern against the original-case word, not just the lowercased form", function(){
@@ -409,6 +430,24 @@ describe("extractor", function(){
                 //  "ABC123" is removed (matches the original-case pattern), "xyz456" is kept
                 //  ("the"/"but" are removed as ordinary English stopwords, unrelated to the regex)
                 extraction_result.should.eql(["unit","failed","xyz456","passed"]);
+            });
+
+            it("should throw a clear error when stopwords_regex contains a non-RegExp entry", function(){
+                (function(){
+                    extractor.extract("10lbs weighed", {
+                        language: "en",
+                        stopwords_regex: ["not-a-regex"]
+                    });
+                }).should.throw("stopwords_regex must be an array of RegExp objects");
+            });
+
+            it("should throw the same error for a non-RegExp entry even when the input trims to empty text", function(){
+                (function(){
+                    extractor.extract("   ", {
+                        language: "en",
+                        stopwords_regex: ["not-a-regex"]
+                    });
+                }).should.throw("stopwords_regex must be an array of RegExp objects");
             });
         });
 

--- a/types/lib/keyword_extractor.d.ts
+++ b/types/lib/keyword_extractor.d.ts
@@ -8,6 +8,7 @@ type ExtractionOptions = {
   remove_duplicates?: boolean;
   return_max_ngrams?: number | false;
   stopwords?: string[];
+  stopwords_regex?: RegExp[];
 } & GetStopwordsOptions;
 
 /** Provides the list of supported ISO 639-1 language codes */


### PR DESCRIPTION
## Summary

- Adds a new `stopwords_regex` option to `extract()` that removes any word matching one or more supplied `RegExp` patterns, in addition to the language's fixed stopword list.
- Addresses #69 — the reporter wanted to strip tokens like `10lbs`, `10Kg`, `1-100`, and `6pm` that aren't practical to list as fixed stopwords since they're arbitrary numeric/unit combinations rather than dictionary words.
- Resets a matched regex's `lastIndex` before each test, so a caller-supplied global/sticky regex can't silently skip alternating matches.
- Updates TypeScript types (`stopwords_regex?: RegExp[]`) and the README (option table + usage example).

## Test plan

- [x] `npm test` — all 80 tests pass (72 pre-existing + 8 new), no regressions.
- [x] New tests cover: the exact patterns from the issue (unit-suffixed numbers, numeric ranges), multiple regexes at once, no-op when the option is omitted or matches nothing, composition with `return_chained_words` (regression-#43 style) and `remove_duplicates`, and stateful/global-regex safety.
- [x] Manually verified the README example reproduces the documented output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8RGGabyiawLPVMCfg8Xgb)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new stopwords_regex option to extract() to remove tokens matching caller-supplied RegExp patterns alongside language stopwords. This enables filtering tokens like 10lbs, 6pm, and 1-100 without expanding fixed stopword lists.

- API/validation: stopwords_regex?: RegExp[] (default []). Only arrays of RegExp are accepted; falsy values act as omitted. Non-array or non-RegExp entries throw a clear error, validated even for empty input; extract("", null) still returns [] as before. Migration: if you previously passed a bare RegExp, wrap it in an array.
- Matching/behavior: a token is dropped if it’s a stopword or matches any pattern. Patterns are cloned with original flags preserved; lastIndex resets before each test; sticky anchoring is preserved. Each pattern is tested against both the lowercased and original-case token for case-sensitive matches.
- Docs/Types/Tests: README documents the option and example; types add stopwords_regex; tests cover multiple patterns, ranges/units, no-op behavior, interaction with return_chained_words and remove_duplicates, global/sticky safety and non-mutation, case-sensitive matching, and validation including empty input.

<sup>Written for commit 41bcdc100d61f0105dcec4515232b452676b983f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/michaeldelorenzo/keyword-extractor/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

